### PR TITLE
env-auth-token

### DIFF
--- a/lib/thegarage/gitx/github.rb
+++ b/lib/thegarage/gitx/github.rb
@@ -91,7 +91,7 @@ module Thegarage
       # @see http://developer.github.com/v3/oauth/#scopes
       # @see http://developer.github.com/v3/#user-agent-required
       def authorization_token
-        auth_token = global_config['token']
+        auth_token = ENV['GITX_GITHUB_TOKEN'] || global_config['token']
         auth_token ||= begin
           new_token = create_authorization
           save_global_config('token' => new_token)

--- a/spec/thegarage/gitx/cli/review_command_spec.rb
+++ b/spec/thegarage/gitx/cli/review_command_spec.rb
@@ -245,6 +245,19 @@ describe Thegarage::Gitx::Cli::ReviewCommand do
         end.to raise_error(/Github user not configured/)
       end
     end
+    context 'when ENV[GITX_GITHUB_TOKEN] is set' do
+      let(:auth_token) { '123123' }
+      before do
+        ENV['GITX_GITHUB_TOKEN'] = auth_token
+        expect(cli).to_not receive(:ask)
+        @auth_token = cli.send(:authorization_token)
+      end
+      after do
+        ENV.delete('GITX_GITHUB_TOKEN')
+      end
+      it { expect(@auth_token).to eq auth_token }
+      it { is_expected.to meet_expectations }
+    end
     context 'when global config token is nil' do
       let(:repo_config) do
         {


### PR DESCRIPTION
### Changelog
- Add GITX_GITHUB_TOKEN env variable for configuration without filesystem

execution from continuous integration servers need to support
configuration via ENV variables to skip prompting users for
passwords in headless environments.

This is inline with 12factor apps best practices as well.
