### PR TITLE
revert-comment-optin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
-rvm:
-  - '2.1.2'
 before_install:
-  - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
-  - git fetch
+- git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+- git fetch
+deploy:
+  provider: rubygems
+  api_key:
+    secure: RHedFaKxfm4yxqJzSEOPZr+OrcS5B1uiPwRjpIHau4hzPysDiTHzjIiFO78o1qrl7UeX9c5k0RQZJGp+9OB/H+WgbyfUzX2C2RbUuHRZubTvFaBvf8qe2D5+7fvj0FdzYS6xKZ23N1FW4vN17M6sViJYlCncB3fxzRA/BHxQlkL1LbQOn9zChI9eZ/gQrKrnziL1IvBSAMygBLHEEMq18lFf+mHiXFJDw/2dghbnPFZh5WYWCbfe/dS7trTJZWax+4xZDmXIqNi3cZiGn5dj2HhMUBX9xHRJORVtplxvP/9ZVuxqdY499DdtsEvemZKEmdggk/jYyxkfKFy+SQSkqRkUAcAS/LmsSn0wkJRiKXSqxTyvF063nct4DQCPjd+HGIFVkVG+4Vknwusg78TZ/BoMlOJnGS7TIuZRdcRujBsoAEqnz9imCz9sMk6IJmyc4XYuwQmPaxQtn0iODt0wAtr3chuPV2IC3j5CdXnXoU00iYS+zZXfVJgBcrdiCuuHnhxGzdKixzgXQ8fUnkniN/uWc0T2X9BvGnf3gyqJEZb7uIXOkozrXF6allXBiM6fXC9X0tL06qjdhaY/WKnmFGThcIBayxrS51GIDcKOGoVaSx/juVDpScwtof2jJplLz09w+36Rz7zMB67xo4yaGp/TPI+CbMc+0+my4+3B9lg=

--- a/gitx.gemspec
+++ b/gitx.gemspec
@@ -35,4 +35,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'terminal-notifier'
   spec.add_development_dependency 'terminal-notifier-guard'
   spec.add_development_dependency 'rubocop'
+
+  # configure gem version for continuous integration builds
+  if ENV['TRAVIS_JOB_NUMBER']
+    digits = spec.version.to_s.split '.'
+    digits[-1] = digits[-1].to_s.succ
+    spec.version = digits.join('.') + ".ci.#{ENV['TRAVIS_JOB_NUMBER']}"
+  end
 end

--- a/lib/gitx/cli/integrate_command.rb
+++ b/lib/gitx/cli/integrate_command.rb
@@ -19,7 +19,7 @@ module Gitx
         begin
           execute_command(UpdateCommand, :update)
         rescue
-          fail MergeError, 'Merge conflict occurred.  Please fix merge conflict and rerun the integrate command'
+          raise MergeError, 'Merge conflict occurred.  Please fix merge conflict and rerun the integrate command'
         end
 
         integrate_branch(branch, integration_branch) unless options[:resume]
@@ -43,7 +43,7 @@ module Gitx
         begin
           run_cmd "git merge #{branch}"
         rescue
-          fail MergeError, "Merge conflict occurred.  Please fix merge conflict and rerun command with --resume #{branch} flag"
+          raise MergeError, "Merge conflict occurred.  Please fix merge conflict and rerun command with --resume #{branch} flag"
         end
         run_cmd 'git push origin HEAD'
       end

--- a/lib/gitx/cli/integrate_command.rb
+++ b/lib/gitx/cli/integrate_command.rb
@@ -10,7 +10,6 @@ module Gitx
       include Gitx::Github
       desc 'integrate', 'integrate the current branch into one of the aggregate development branches (default = staging)'
       method_option :resume, type: :string, aliases: '-r', desc: 'resume merging of feature-branch'
-      method_option :comment, type: :boolean, aliases: '-c', desc: 'add a comment to the pull request for this branch. Creates a new PR if none exists.'
       def integrate(integration_branch = 'staging')
         assert_aggregate_branch!(integration_branch)
 
@@ -20,13 +19,13 @@ module Gitx
         begin
           execute_command(UpdateCommand, :update)
         rescue
-          raise MergeError, 'Merge Conflict Occurred. Please fix merge conflict and rerun the integrate command'
+          fail MergeError, 'Merge conflict occurred.  Please fix merge conflict and rerun the integrate command'
         end
 
         integrate_branch(branch, integration_branch) unless options[:resume]
         checkout_branch branch
 
-        create_integrate_comment(branch) if options[:comment] && !config.reserved_branch?(branch)
+        create_integrate_comment(branch) unless config.reserved_branch?(branch)
       end
 
       private
@@ -44,7 +43,7 @@ module Gitx
         begin
           run_cmd "git merge #{branch}"
         rescue
-          raise MergeError, "Merge Conflict Occurred. Please fix merge conflict and rerun command with --resume #{branch} flag"
+          fail MergeError, "Merge conflict occurred.  Please fix merge conflict and rerun command with --resume #{branch} flag"
         end
         run_cmd 'git push origin HEAD'
       end

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.13.3'
+  VERSION = '2.13.4'
 end

--- a/spec/gitx/cli/integrate_command_spec.rb
+++ b/spec/gitx/cli/integrate_command_spec.rb
@@ -48,7 +48,7 @@ describe Gitx::Cli::IntegrateCommand do
         should meet_expectations
       end
       it 'posts comment to pull request' do
-        expect(WebMock).to have_requested(:post, "https://api.github.com/repos/wireframe/gitx/issues/10/comments")
+        expect(WebMock).to have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
           .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
       end
     end
@@ -74,7 +74,7 @@ describe Gitx::Cli::IntegrateCommand do
         expect(WebMock).to_not have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/pulls')
       end
       it 'does not post comment on pull request' do
-        expect(WebMock).to_not have_requested(:post, "https://api.github.com/repos/wireframe/gitx/issues/10/comments")
+        expect(WebMock).to_not have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
       end
     end
     context 'when a pull request doesnt exist for the feature-branch' do
@@ -82,11 +82,11 @@ describe Gitx::Cli::IntegrateCommand do
       let(:changelog) { '* made some fixes' }
       let(:new_pull_request) do
         {
-          html_url: "https://path/to/html/pull/request",
-          issue_url: "https://api/path/to/issue/url",
+          html_url: 'https://path/to/html/pull/request',
+          issue_url: 'https://api/path/to/issue/url',
           number: 10,
           head: {
-            ref: "branch_name"
+            ref: 'branch_name'
           }
         }
       end
@@ -95,17 +95,17 @@ describe Gitx::Cli::IntegrateCommand do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update).twice
 
-        expect(cli).to receive(:run_cmd).with("git fetch origin").ordered
-        expect(cli).to receive(:run_cmd).with("git branch -D staging", allow_failure: true).ordered
-        expect(cli).to receive(:run_cmd).with("git checkout staging").ordered
-        expect(cli).to receive(:run_cmd).with("git merge feature-branch").ordered
-        expect(cli).to receive(:run_cmd).with("git push origin HEAD").ordered
-        expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
+        expect(cli).to receive(:run_cmd).with('git fetch origin').ordered
+        expect(cli).to receive(:run_cmd).with('git branch -D staging', allow_failure: true).ordered
+        expect(cli).to receive(:run_cmd).with('git checkout staging').ordered
+        expect(cli).to receive(:run_cmd).with('git merge feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %s%n%b'").and_return("2013-01-01 did some stuff").ordered
+        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %s%n%b'").and_return('2013-01-01 did some stuff').ordered
 
-        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(:status => 201, :body => new_pull_request.to_json, :headers => {'Content-Type' => 'application/json'})
-        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments').to_return(:status => 201)
+        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
+        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments').to_return(status: 201)
 
         VCR.use_cassette('pull_request_does_not_exist') do
           cli.integrate
@@ -115,7 +115,7 @@ describe Gitx::Cli::IntegrateCommand do
         should meet_expectations
       end
       it 'creates github comment for integration' do
-        expect(WebMock).to have_requested(:post, "https://api.github.com/repos/wireframe/gitx/issues/10/comments")
+        expect(WebMock).to have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
           .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
       end
       it 'runs expected commands' do

--- a/spec/gitx/cli/integrate_command_spec.rb
+++ b/spec/gitx/cli/integrate_command_spec.rb
@@ -47,8 +47,9 @@ describe Gitx::Cli::IntegrateCommand do
       it 'defaults to staging branch' do
         should meet_expectations
       end
-      it 'does not post comment to pull request' do
-        expect(WebMock).to_not have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
+      it 'posts comment to pull request' do
+        expect(WebMock).to have_requested(:post, "https://api.github.com/repos/wireframe/gitx/issues/10/comments")
+          .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
       end
     end
     context 'when current_branch == master' do
@@ -71,6 +72,54 @@ describe Gitx::Cli::IntegrateCommand do
       end
       it 'does not create pull request' do
         expect(WebMock).to_not have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/pulls')
+      end
+      it 'does not post comment on pull request' do
+        expect(WebMock).to_not have_requested(:post, "https://api.github.com/repos/wireframe/gitx/issues/10/comments")
+      end
+    end
+    context 'when a pull request doesnt exist for the feature-branch' do
+      let(:authorization_token) { '123123' }
+      let(:changelog) { '* made some fixes' }
+      let(:new_pull_request) do
+        {
+          html_url: "https://path/to/html/pull/request",
+          issue_url: "https://api/path/to/issue/url",
+          number: 10,
+          head: {
+            ref: "branch_name"
+          }
+        }
+      end
+      before do
+        allow(cli).to receive(:ask_editor).and_return('description')
+        allow(cli).to receive(:authorization_token).and_return(authorization_token)
+        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update).twice
+
+        expect(cli).to receive(:run_cmd).with("git fetch origin").ordered
+        expect(cli).to receive(:run_cmd).with("git branch -D staging", allow_failure: true).ordered
+        expect(cli).to receive(:run_cmd).with("git checkout staging").ordered
+        expect(cli).to receive(:run_cmd).with("git merge feature-branch").ordered
+        expect(cli).to receive(:run_cmd).with("git push origin HEAD").ordered
+        expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
+        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %s%n%b'").and_return("2013-01-01 did some stuff").ordered
+
+        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(:status => 201, :body => new_pull_request.to_json, :headers => {'Content-Type' => 'application/json'})
+        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments').to_return(:status => 201)
+
+        VCR.use_cassette('pull_request_does_not_exist') do
+          cli.integrate
+        end
+      end
+      it 'creates github pull request' do
+        should meet_expectations
+      end
+      it 'creates github comment for integration' do
+        expect(WebMock).to have_requested(:post, "https://api.github.com/repos/wireframe/gitx/issues/10/comments")
+          .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
+      end
+      it 'runs expected commands' do
+        should meet_expectations
       end
     end
     context 'when staging branch does not exist remotely' do
@@ -135,7 +184,7 @@ describe Gitx::Cli::IntegrateCommand do
       before do
         expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update).and_raise(Gitx::Cli::BaseCommand::MergeError)
 
-        expect { cli.integrate }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge Conflict Occurred. Please Merge Conflict Occurred. Please fix merge conflict and rerun the integrate command')
+        expect { cli.integrate }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge conflict occurred.  Please fix merge conflict and rerun the integrate command')
       end
       it 'raises a helpful error' do
         should meet_expectations
@@ -151,7 +200,7 @@ describe Gitx::Cli::IntegrateCommand do
         expect(cli).to receive(:run_cmd).with('git checkout staging').ordered
         expect(cli).to receive(:run_cmd).with('git merge feature-branch').and_raise('git merge feature-branch failed').ordered
 
-        expect { cli.integrate }.to raise_error(/Merge Conflict Occurred. Please fix merge conflict and rerun command with --resume feature-branch flag/)
+        expect { cli.integrate }.to raise_error(/Merge conflict occurred.  Please fix merge conflict and rerun command with --resume feature-branch flag/)
       end
       it 'raises a helpful error' do
         should meet_expectations
@@ -208,82 +257,6 @@ describe Gitx::Cli::IntegrateCommand do
       end
       it 'asks user for feature-branch name' do
         should meet_expectations
-      end
-    end
-    context 'for default integration (to staging) with --comment flag' do
-      let(:options) do
-        { comment: true }
-      end
-      let(:authorization_token) { '123123' }
-      let(:remote_branch_names) { ['origin/staging'] }
-      before do
-        allow(cli).to receive(:authorization_token).and_return(authorization_token)
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
-        expect(cli).to receive(:run_cmd).with('git fetch origin').ordered
-        expect(cli).to receive(:run_cmd).with('git branch -D staging', allow_failure: true).ordered
-        expect(cli).to receive(:run_cmd).with('git checkout staging').ordered
-        expect(cli).to receive(:run_cmd).with('git merge feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-
-        stub_request(:post, /.*api.github.com.*/).to_return(status: 201)
-
-        VCR.use_cassette('pull_request_does_exist_with_success_status') do
-          cli.integrate
-        end
-      end
-      it 'defaults to staging branch' do
-        should meet_expectations
-      end
-      it 'posts comment to pull request' do
-        expect(WebMock).to have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
-          .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
-      end
-    end
-    context 'with --comment flag when a pull request doesn\'t exist for the feature-branch' do
-      let(:options) do
-        { comment: true }
-      end
-      let(:authorization_token) { '123123' }
-      let(:changelog) { '* made some fixes' }
-      let(:new_pull_request) do
-        {
-          html_url: 'https://path/to/html/pull/request',
-          issue_url: 'https://api/path/to/issue/url',
-          number: 10,
-          head: {
-            ref: 'branch_name'
-          }
-        }
-      end
-      before do
-        allow(cli).to receive(:ask_editor).and_return('description')
-        allow(cli).to receive(:authorization_token).and_return(authorization_token)
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update).twice
-
-        expect(cli).to receive(:run_cmd).with('git fetch origin').ordered
-        expect(cli).to receive(:run_cmd).with('git branch -D staging', allow_failure: true).ordered
-        expect(cli).to receive(:run_cmd).with('git checkout staging').ordered
-        expect(cli).to receive(:run_cmd).with('git merge feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %s%n%b'").and_return('2013-01-01 did some stuff').ordered
-
-        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
-        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments').to_return(status: 201)
-
-        VCR.use_cassette('pull_request_does_not_exist') do
-          cli.integrate
-        end
-      end
-      it 'creates github pull request' do
-        should meet_expectations
-      end
-      it 'creates github comment for integration' do
-        expect(WebMock).to have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
-          .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
       end
     end
   end


### PR DESCRIPTION
### Changelog
- Always create comment on pull request when integrating for auditing purposes.

Reverts 8f061be8a5907111aa3c4ea9b3cb954fe9856a6d
