### PR TITLE
yaml-defaults

### DIFF
--- a/lib/gitx/configuration.rb
+++ b/lib/gitx/configuration.rb
@@ -2,19 +2,14 @@ require 'yaml'
 
 module Gitx
   class Configuration
-    DEFAULT_CONFIG = {
-      'aggregate_branches' => %w( staging prototype ),
-      'reserved_branches' => %w( HEAD master next_release staging prototype ),
-      'taggable_branches' => %w( master staging )
-    }
     CONFIG_FILE = '.gitx.yml'
 
     attr_reader :config
 
     def initialize(root_dir)
-      @config = Thor::CoreExt::HashWithIndifferentAccess.new(DEFAULT_CONFIG)
-      config_file_path = File.join(root_dir, CONFIG_FILE)
-      @config.merge!(::YAML.load_file(config_file_path)) if File.exist?(config_file_path)
+      @config = Thor::CoreExt::HashWithIndifferentAccess.new
+      @config.merge!(load_config(File.join(__dir__, 'defaults.yml')))
+      @config.merge!(load_config(File.join(root_dir, CONFIG_FILE)))
     end
 
     def aggregate_branches
@@ -39,6 +34,17 @@ module Gitx
 
     def taggable_branch?(branch)
       taggable_branches.include?(branch)
+    end
+
+    private
+
+    # load configuration file
+    def load_config(path)
+      if File.exist?(path)
+        ::YAML.load_file(path)
+      else
+        {}
+      end
     end
   end
 end

--- a/lib/gitx/defaults.yml
+++ b/lib/gitx/defaults.yml
@@ -1,0 +1,13 @@
+---
+aggregate_branches:
+  - staging
+  - prototype
+reserved_branches:
+  - HEAD
+  - master
+  - next_release
+  - staging
+  - prototype
+taggable_branches:
+  - master
+  - staging

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.14.1'
+  VERSION = '2.14.2'
 end

--- a/spec/gitx/cli/base_command_spec.rb
+++ b/spec/gitx/cli/base_command_spec.rb
@@ -14,7 +14,7 @@ describe Gitx::Cli::BaseCommand do
 
   describe 'without custom .gitx.yml config file' do
     it 'provides default options' do
-      expect(cli.send(:config).config).to eq Gitx::Configuration::DEFAULT_CONFIG
+      expect(cli.send(:config).config).to eq ::YAML.load_file(File.join(__dir__, '../../../lib/gitx/defaults.yml'))
     end
   end
 

--- a/spec/gitx/cli/base_command_spec.rb
+++ b/spec/gitx/cli/base_command_spec.rb
@@ -13,6 +13,9 @@ describe Gitx::Cli::BaseCommand do
   let(:repo) { cli.send(:repo) }
 
   describe 'without custom .gitx.yml config file' do
+    before do
+      expect(repo).to receive(:workdir).and_return(temp_dir)
+    end
     it 'provides default options' do
       expect(cli.send(:config).config).to eq ::YAML.load_file(File.join(__dir__, '../../../lib/gitx/defaults.yml'))
     end


### PR DESCRIPTION
### Changelog
- Extract default config to YAML file

Fixes #12

Why?
- keep code consistant so that anything defined in default YAML can be
  easily overridden by custom config
