### PR TITLE
after-release-configuration

### DIFF
--- a/.gitx.yml
+++ b/.gitx.yml
@@ -1,0 +1,3 @@
+---
+after_release:
+  - rake release

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ reset an aggregate branch (ex: prototype, staging) back to a known good state.
 
 create a build tag for the current Travis-CI build and push it back to origin
 
+## Configuration
+Any of the [default settings defined in the gem](lib/gitx/defaults.yml) can be overridden
+by creating a custom `.gitx.yml` file in the root directory of your project.
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/lib/gitx/configuration.rb
+++ b/lib/gitx/configuration.rb
@@ -36,6 +36,10 @@ module Gitx
       taggable_branches.include?(branch)
     end
 
+    def after_release_scripts
+      config[:after_release]
+    end
+
     private
 
     # load configuration file

--- a/lib/gitx/defaults.yml
+++ b/lib/gitx/defaults.yml
@@ -11,3 +11,5 @@ reserved_branches:
 taggable_branches:
   - master
   - staging
+after_release:
+  - git integrate

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.14.2'
+  VERSION = '2.15.0'
 end


### PR DESCRIPTION
### Changelog
- Add after_release configuration for custom scripts

Fixes #13

What changed?
- add after_release config options for an array of scripts to run after
  successful release merge
- move default after release behavior to configuration instead of
  being hardcoded in the command (git integrate + git cleanup)
- update gitx gem to automatically run "rake release" after releasing a
  branch
