### PR TITLE
release commit message

### DIFF
--- a/lib/gitx/cli/release_command.rb
+++ b/lib/gitx/cli/release_command.rb
@@ -20,11 +20,12 @@ module Gitx
         checkout_branch(branch)
         execute_command(UpdateCommand, :update)
 
+        pull_request = find_or_create_pull_request(branch)
         return unless confirm_branch_status?(branch)
 
         checkout_branch Gitx::BASE_BRANCH
         run_cmd "git pull origin #{Gitx::BASE_BRANCH}"
-        run_cmd "git merge --no-ff #{branch}"
+        run_cmd %Q(git merge --no-ff -m "[gitx] Releasing #{branch} to #{Gitx::BASE_BRANCH} (Pull request ##{pull_request.number})" #{branch})
         run_cmd 'git push origin HEAD'
 
         after_release
@@ -33,7 +34,6 @@ module Gitx
       private
 
       def confirm_branch_status?(branch)
-        find_or_create_pull_request(branch)
         status = branch_status(branch)
         if status == 'success'
           true

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.15.0'
+  VERSION = '2.16.0'
 end

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.16.0'
+  VERSION = '2.16.0.pre'
 end

--- a/spec/gitx/cli/release_command_spec.rb
+++ b/spec/gitx/cli/release_command_spec.rb
@@ -41,7 +41,7 @@ describe Gitx::Cli::ReleaseCommand do
 
         expect(cli).to_not receive(:run_cmd).with('git checkout master')
         expect(cli).to_not receive(:run_cmd).with('git pull origin master')
-        expect(cli).to_not receive(:run_cmd).with('git merge --no-ff feature-branch')
+        expect(cli).to_not receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch')
         expect(cli).to_not receive(:run_cmd).with('git push origin HEAD')
 
         VCR.use_cassette('pull_request_does_exist_with_failure_status') do
@@ -64,7 +64,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git checkout master').ordered
         expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git integrate').ordered
 
@@ -95,7 +95,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git checkout master').ordered
         expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('echo hello').ordered
 
@@ -118,7 +118,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git checkout master').ordered
         expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git integrate').ordered
 
@@ -156,7 +156,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %B'").and_return('2013-01-01 did some stuff').ordered
         expect(cli).to receive(:run_cmd).with('git checkout master').ordered
         expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git integrate').ordered
 
@@ -188,7 +188,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git checkout master').ordered
         expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff feature-branch').ordered
+        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git integrate').ordered
         expect(cli).to receive(:run_cmd).with('git cleanup').ordered


### PR DESCRIPTION
### What changed?
- Customize commit message when releasing branch

Fixes #9

What changed?
- add reference to pull request issue id
- add [gitx] prefix to release merge messages

Why?
- simulate github commit button w/ reference to github pull request id
  to magically support the github "revert this branch" feature

Resources:
- https://help.github.com/articles/reverting-a-pull-request/
