### PR TITLE
start with issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ so they are available without learning any new commands!
 
 update local repository with latest upstream changes and create a new feature branch
 
+options:
+* `--issue` or `-i` = reference to github issue id this branch is related to
+
 ## git update
 
 update the local feature branch with latest remote changes plus upstream released changes.

--- a/lib/gitx/cli/start_command.rb
+++ b/lib/gitx/cli/start_command.rb
@@ -9,6 +9,7 @@ module Gitx
       VALID_BRANCH_NAME_REGEX = /^[A-Za-z0-9\-_]+$/
 
       desc 'start', 'start a new git branch with latest changes from master'
+      method_option :issue, type: :numeric, aliases: '-i', desc: 'Github issue number'
       def start(branch_name = nil)
         until valid_new_branch_name?(branch_name)
           branch_name = ask("What would you like to name your branch? (ex: #{EXAMPLE_BRANCH_NAMES.sample})")
@@ -18,6 +19,7 @@ module Gitx
         run_cmd 'git pull'
         repo.create_branch branch_name, Gitx::BASE_BRANCH
         checkout_branch branch_name
+        run_cmd(%Q(git commit -m "Starting work on #{branch_name} (Issue ##{options[:issue]})" --allow-empty)) if options[:issue]
       end
 
       private

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.17.0.pre'
+  VERSION = '2.18.0.pre'
 end

--- a/spec/gitx/cli/start_command_spec.rb
+++ b/spec/gitx/cli/start_command_spec.rb
@@ -9,7 +9,7 @@ describe Gitx::Cli::StartCommand do
       pretend: true
     }
   end
-  let(:cli) { Gitx::Cli::StartCommand.new(args, options, config) }
+  let(:cli) { described_class.new(args, options, config) }
   let(:repo) { cli.send(:repo) }
 
   describe '#start' do
@@ -89,6 +89,25 @@ describe Gitx::Cli::StartCommand do
         cli.start 'bar'
       end
       it 'prompts user to enter a new branch name' do
+        should meet_expectations
+      end
+    end
+    context 'when --issue option is used' do
+      let(:options) do
+        {
+          issue: 10
+        }
+      end
+      before do
+        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(cli).to receive(:checkout_branch).with('new-branch').ordered
+        expect(cli).to receive(:run_cmd).with('git commit -m "Starting work on new-branch (Issue #10)" --allow-empty').ordered
+
+        cli.start 'new-branch'
+      end
+      it 'creates empty commit with link to issue id' do
         should meet_expectations
       end
     end


### PR DESCRIPTION
### What changed?
- Add --issue option to git start command

Fixes #21

Example usage:
$ git start --issue 20

Automatically creates an empty commit on the new branch which references
the github issue number.  This commit will be included in the changelog
when creating a pull request and make it simpler to reference the
original issue in the pull request body (to autoclose issues)
