### PR TITLE
remove integration comment

### DIFF
--- a/lib/gitx/cli/integrate_command.rb
+++ b/lib/gitx/cli/integrate_command.rb
@@ -25,7 +25,6 @@ module Gitx
         pull_request = pull_request_for_branch(branch)
         integrate_branch(branch, integration_branch, pull_request) unless options[:resume]
         checkout_branch branch
-        create_integrate_comment(pull_request) if pull_request
       end
 
       private
@@ -88,11 +87,6 @@ module Gitx
       def create_remote_branch(target_branch)
         repo.create_branch(target_branch, Gitx::BASE_BRANCH)
         run_cmd "git push origin #{target_branch}:#{target_branch}"
-      end
-
-      def create_integrate_comment(pull_request)
-        comment = '[gitx] integrated into staging :twisted_rightwards_arrows:'
-        github_client.add_comment(github_slug, pull_request.number, comment)
       end
     end
   end

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.18.0'
+  VERSION = '2.19.0'
 end

--- a/spec/gitx/cli/integrate_command_spec.rb
+++ b/spec/gitx/cli/integrate_command_spec.rb
@@ -38,18 +38,12 @@ describe Gitx::Cli::IntegrateCommand do
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
 
-        stub_request(:post, /.*api.github.com.*/).to_return(status: 201)
-
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.integrate
         end
       end
       it 'defaults to staging branch' do
         should meet_expectations
-      end
-      it 'posts comment to pull request' do
-        expect(WebMock).to have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
-          .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
       end
     end
     context 'when current_branch == master' do
@@ -70,9 +64,6 @@ describe Gitx::Cli::IntegrateCommand do
       end
       it 'does not create pull request' do
         expect(WebMock).to_not have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/pulls')
-      end
-      it 'does not post comment on pull request' do
-        expect(WebMock).to_not have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
       end
     end
     context 'when a pull request doesnt exist for the feature-branch' do
@@ -101,7 +92,6 @@ describe Gitx::Cli::IntegrateCommand do
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
-        stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments').to_return(status: 201)
 
         VCR.use_cassette('pull_request_does_not_exist') do
           cli.integrate
@@ -109,10 +99,6 @@ describe Gitx::Cli::IntegrateCommand do
       end
       it 'creates github pull request' do
         should meet_expectations
-      end
-      it 'creates github comment for integration' do
-        expect(WebMock).to have_requested(:post, 'https://api.github.com/repos/wireframe/gitx/issues/10/comments')
-          .with(body: { body: '[gitx] integrated into staging :twisted_rightwards_arrows:' })
       end
       it 'runs expected commands' do
         should meet_expectations
@@ -134,8 +120,6 @@ describe Gitx::Cli::IntegrateCommand do
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
 
-        stub_request(:post, /.*api.github.com.*/).to_return(status: 201)
-
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.integrate
         end
@@ -155,8 +139,6 @@ describe Gitx::Cli::IntegrateCommand do
         expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Integrating feature-branch into prototype (Pull request #10)" feature-branch').ordered
         expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-
-        stub_request(:post, /.*api.github.com.*/).to_return(status: 201)
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.integrate 'prototype'
@@ -214,8 +196,6 @@ describe Gitx::Cli::IntegrateCommand do
         expect(cli).not_to receive(:run_cmd).with('git push origin HEAD')
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch')
 
-        stub_request(:post, /.*api.github.com.*/).to_return(status: 201)
-
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.integrate
         end
@@ -239,7 +219,6 @@ describe Gitx::Cli::IntegrateCommand do
         expect(cli).not_to receive(:run_cmd).with('git push origin HEAD')
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
 
-        stub_request(:post, /.*api.github.com.*/).to_return(status: 201)
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.integrate
         end


### PR DESCRIPTION
### What changed?
- Do not create comments when integrating feature

Fixes #25

Why?
- no longer needed now that integration commits reference the pull
  request
