### PR TITLE
configurable base branch

### DIFF
--- a/lib/gitx.rb
+++ b/lib/gitx.rb
@@ -2,7 +2,3 @@ require 'gitx/version'
 require 'gitx/configuration'
 require 'gitx/extensions/string'
 require 'gitx/extensions/thor'
-
-module Gitx
-  BASE_BRANCH = 'master'
-end

--- a/lib/gitx/cli/cleanup_command.rb
+++ b/lib/gitx/cli/cleanup_command.rb
@@ -7,12 +7,12 @@ module Gitx
     class CleanupCommand < BaseCommand
       desc 'cleanup', 'Cleanup branches that have been merged into master from the repo'
       def cleanup
-        checkout_branch Gitx::BASE_BRANCH
+        checkout_branch config.base_branch
         run_cmd 'git pull'
         run_cmd 'git remote prune origin'
 
         say 'Deleting local and remote branches that have been merged into '
-        say Gitx::BASE_BRANCH, :green
+        say config.base_branch, :green
         merged_branches(remote: true).each do |branch|
           run_cmd "git push origin --delete #{branch}"
         end

--- a/lib/gitx/cli/integrate_command.rb
+++ b/lib/gitx/cli/integrate_command.rb
@@ -85,7 +85,7 @@ module Gitx
       end
 
       def create_remote_branch(target_branch)
-        repo.create_branch(target_branch, Gitx::BASE_BRANCH)
+        repo.create_branch(target_branch, config.base_branch)
         run_cmd "git push origin #{target_branch}:#{target_branch}"
       end
     end

--- a/lib/gitx/cli/nuke_command.rb
+++ b/lib/gitx/cli/nuke_command.rb
@@ -21,13 +21,13 @@ module Gitx
         say 'branch to '
         say last_known_good_tag, :green
 
-        checkout_branch Gitx::BASE_BRANCH
+        checkout_branch config.base_branch
         run_cmd "git branch -D #{bad_branch}", allow_failure: true
         run_cmd "git push origin --delete #{bad_branch}", allow_failure: true
         run_cmd "git checkout -b #{bad_branch} #{last_known_good_tag}"
         run_cmd "git push origin #{bad_branch}"
         run_cmd "git branch --set-upstream-to origin/#{bad_branch}"
-        checkout_branch Gitx::BASE_BRANCH
+        checkout_branch config.base_branch
       end
 
       private

--- a/lib/gitx/cli/release_command.rb
+++ b/lib/gitx/cli/release_command.rb
@@ -12,7 +12,7 @@ module Gitx
       desc 'release', 'release the current branch to production'
       method_option :cleanup, type: :boolean, desc: 'cleanup merged branches after release'
       def release(branch = nil)
-        return unless yes?("Release #{current_branch.name} to #{Gitx::BASE_BRANCH}? (y/n)", :green)
+        return unless yes?("Release #{current_branch.name} to #{config.base_branch}? (y/n)", :green)
 
         branch ||= current_branch.name
         assert_not_protected_branch!(branch, 'release')
@@ -22,9 +22,9 @@ module Gitx
         pull_request = find_or_create_pull_request(branch)
         return unless confirm_branch_status?(branch)
 
-        checkout_branch Gitx::BASE_BRANCH
-        run_cmd "git pull origin #{Gitx::BASE_BRANCH}"
-        run_cmd %Q(git merge --no-ff -m "[gitx] Releasing #{branch} to #{Gitx::BASE_BRANCH} (Pull request ##{pull_request.number})" #{branch})
+        checkout_branch config.base_branch
+        run_cmd "git pull origin #{config.base_branch}"
+        run_cmd %Q(git merge --no-ff -m "[gitx] Releasing #{branch} to #{config.base_branch} (Pull request ##{pull_request.number})" #{branch})
         run_cmd 'git push origin HEAD'
 
         after_release

--- a/lib/gitx/cli/start_command.rb
+++ b/lib/gitx/cli/start_command.rb
@@ -15,9 +15,9 @@ module Gitx
           branch_name = ask("What would you like to name your branch? (ex: #{EXAMPLE_BRANCH_NAMES.sample})")
         end
 
-        checkout_branch Gitx::BASE_BRANCH
+        checkout_branch config.base_branch
         run_cmd 'git pull'
-        repo.create_branch branch_name, Gitx::BASE_BRANCH
+        repo.create_branch branch_name, config.base_branch
         checkout_branch branch_name
         run_cmd(%Q(git commit -m "Starting work on #{branch_name} (Issue ##{options[:issue]})" --allow-empty)) if options[:issue]
       end

--- a/lib/gitx/cli/update_command.rb
+++ b/lib/gitx/cli/update_command.rb
@@ -10,10 +10,10 @@ module Gitx
         say 'Updating '
         say "#{current_branch.name} ", :green
         say 'with latest changes from '
-        say Gitx::BASE_BRANCH, :green
+        say config.base_branch, :green
 
         update_branch(current_branch.name) if remote_branch_exists?(current_branch.name)
-        update_branch(Gitx::BASE_BRANCH)
+        update_branch(config.base_branch)
         run_cmd 'git push origin HEAD'
       end
 

--- a/lib/gitx/configuration.rb
+++ b/lib/gitx/configuration.rb
@@ -12,6 +12,10 @@ module Gitx
       @config.merge!(load_config(File.join(root_dir, CONFIG_FILE)))
     end
 
+    def base_branch
+      config[:base_branch]
+    end
+
     def aggregate_branches
       config[:aggregate_branches]
     end

--- a/lib/gitx/defaults.yml
+++ b/lib/gitx/defaults.yml
@@ -1,4 +1,7 @@
 ---
+# default base branch
+base_branch: master
+
 # list of branches eligable for integration
 aggregate_branches:
   - staging

--- a/lib/gitx/github.rb
+++ b/lib/gitx/github.rb
@@ -61,17 +61,17 @@ module Gitx
       say 'Creating pull request for '
       say "#{branch} ", :green
       say 'against '
-      say "#{Gitx::BASE_BRANCH} ", :green
+      say "#{config.base_branch} ", :green
       say 'in '
       say github_slug, :green
 
       title = branch.gsub(/[-_]/, ' ')
       body = pull_request_body(branch)
-      github_client.create_pull_request(github_slug, Gitx::BASE_BRANCH, branch, title, body)
+      github_client.create_pull_request(github_slug, config.base_branch, branch, title, body)
     end
 
     def pull_request_body(branch)
-      changelog = run_cmd("git log #{Gitx::BASE_BRANCH}...#{branch} --reverse --no-merges --pretty=format:'* %B'")
+      changelog = run_cmd("git log #{config.base_branch}...#{branch} --reverse --no-merges --pretty=format:'* %B'")
       description = options[:description]
 
       description_template = []

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.20.0'
+  VERSION = '2.21.0'
 end

--- a/spec/gitx/cli/review_command_spec.rb
+++ b/spec/gitx/cli/review_command_spec.rb
@@ -10,7 +10,8 @@ describe Gitx::Cli::ReviewCommand do
     }
   end
   let(:cli) { described_class.new(args, options, config) }
-  let(:repo) { double('fake repo', config: repo_config) }
+  let(:repo) { double('fake repo', config: repo_config, workdir: repo_workdir) }
+  let(:repo_workdir) { File.expand_path(File.join(__dir__, '../../../')) }
   let(:repo_config) do
     {
       'remote.origin.url' => 'https://github.com/wireframe/gitx'


### PR DESCRIPTION
### What changed?
- Allow for projects to override the default base branch

This setting can be used for a "modified" version of gitflow
where a project temporarily sets it's base branch to something other
than master for a period of time.
