### PR TITLE
pull request template

### DIFF
--- a/lib/gitx/cli/review_command.rb
+++ b/lib/gitx/cli/review_command.rb
@@ -11,22 +11,23 @@ module Gitx
       BUMP_COMMENT_PREFIX = '[gitx] review bump :tada:'
       BUMP_COMMENT_FOOTER = <<-EOS.dedent
         # Bump comments should include:
-        # * summary of what changed
+        # * Summary of what changed
         #
         # This footer will automatically be stripped from the created comment
       EOS
       APPROVAL_COMMENT_PREFIX  = '[gitx] review approved :shipit:'
       APPROVAL_COMMENT_FOOTER = <<-EOS.dedent
         # Approval comments can include:
-        # * feedback
-        # * post-release follow-up items
+        # * Feedback
+        # * Follow-up items for after release
         #
         # This footer will automatically be stripped from the created comment
       EOS
       REJECTION_COMMENT_PREFIX = '[gitx] review rejected'
       REJECTION_COMMENT_FOOTER = <<-EOS.dedent
         # Rejection comments should include:
-        # * feedback for fixes required before approved
+        # * Feedback
+        # * Required changes before approved
         #
         # This footer will automatically be stripped from the created comment
       EOS

--- a/lib/gitx/github.rb
+++ b/lib/gitx/github.rb
@@ -10,9 +10,11 @@ module Gitx
     CLIENT_URL = 'https://github.com/wireframe/gitx'
     PULL_REQUEST_FOOTER = <<-EOS.dedent
       # Pull Request Protips(tm):
-      # * Include description of how this change accomplishes the task at hand.
+      # * Describe how this change accomplishes the task at hand
       # * Use GitHub flavored Markdown http://github.github.com/github-flavored-markdown/
-      # * Review CONTRIBUTING.md for recommendations of artifacts, links, images, screencasts, etc.
+      # * Include links to relevent resources and related tickets
+      # * Attach build artifacts, images, screenshots, screencasts, etc
+      # * Review CONTRIBUTING.md for relevant workflow requirements
       #
       # This footer will automatically be stripped from the pull request description
     EOS
@@ -76,10 +78,7 @@ module Gitx
 
       description_template = []
       description_template << "#{description}\n" if description
-      description_template << '### What changed?'
       description_template << changelog
-      description_template << "### What was fixed?\n"
-      description_template << "### What else needs to be done?"
 
       body = ask_editor(description_template.join("\n"), editor: repo.config['core.editor'], footer: PULL_REQUEST_FOOTER)
     end

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.21.0'
+  VERSION = '2.21.1'
 end

--- a/spec/gitx/cli/review_command_spec.rb
+++ b/spec/gitx/cli/review_command_spec.rb
@@ -47,7 +47,7 @@ describe Gitx::Cli::ReviewCommand do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
         expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %B'").and_return(changelog).ordered
-        expect(cli).to receive(:ask_editor).with("### What changed?\n#{changelog}\n### What was fixed?\n\n### What else needs to be done?", hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return('description')
+        expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return('description')
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
 
@@ -84,7 +84,7 @@ describe Gitx::Cli::ReviewCommand do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
         expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %B'").and_return(changelog).ordered
-        expect(cli).to receive(:ask_editor).with("### What changed?\n#{changelog}\n### What was fixed?\n\n### What else needs to be done?", hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return(pull_request_description)
+        expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return(pull_request_description)
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls')
           .with(body: {base: 'master', head: 'feature-branch', title: 'feature branch', body: pull_request_description}.to_json)


### PR DESCRIPTION
- Tweak pull request template

Change from "fill in the template" back to using the footer comments for
recommended pull request best practices.
