### PR TITLE
run cmd args

### DIFF
--- a/lib/gitx/cli/base_command.rb
+++ b/lib/gitx/cli/base_command.rb
@@ -26,6 +26,10 @@ module Gitx
         end
       end
 
+      def run_git_cmd(*cmd)
+        run_cmd('git', *cmd)
+      end
+
       def checkout_branch(branch_name)
         run_cmd "git checkout #{branch_name}"
       end

--- a/lib/gitx/cli/start_command.rb
+++ b/lib/gitx/cli/start_command.rb
@@ -16,10 +16,10 @@ module Gitx
         end
 
         checkout_branch config.base_branch
-        run_cmd 'git pull'
+        run_git_cmd 'pull'
         repo.create_branch branch_name, config.base_branch
         checkout_branch branch_name
-        run_cmd(%Q(git commit -m "Starting work on #{branch_name} (Issue ##{options[:issue]})" --allow-empty)) if options[:issue]
+        run_git_cmd('commit', '--allow-empty', '--message', "Starting work on #{branch_name} (Issue ##{options[:issue]})") if options[:issue]
       end
 
       private

--- a/lib/gitx/extensions/thor.rb
+++ b/lib/gitx/extensions/thor.rb
@@ -12,7 +12,7 @@ class Thor
 
       Open3.popen2e(*cmd) do |stdin, stdout_err, wait_thr|
         while line = stdout_err.gets
-          say line, :yellow
+          say(line, :yellow) if options[:trace]
           output << line
         end
 

--- a/spec/gitx/cli/start_command_spec.rb
+++ b/spec/gitx/cli/start_command_spec.rb
@@ -11,12 +11,15 @@ describe Gitx::Cli::StartCommand do
   end
   let(:cli) { described_class.new(args, options, config) }
   let(:repo) { cli.send(:repo) }
+  let(:exit_value) { double(:exit_value, success?: true) }
+  let(:thread) { double(:thread, value: exit_value) }
+  let(:stdoutput) { StringIO.new('') }
 
   describe '#start' do
     context 'when user inputs branch that is valid' do
       before do
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -31,7 +34,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -46,7 +49,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -64,7 +67,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -82,7 +85,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -100,10 +103,10 @@ describe Gitx::Cli::StartCommand do
       end
       before do
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git commit -m "Starting work on new-branch (Issue #10)" --allow-empty').ordered
+        expect(Open3).to receive(:popen2e).with('git', 'commit', '--allow-empty', '--message', 'Starting work on new-branch (Issue #10)').and_yield(nil, stdoutput, thread).ordered
 
         cli.start 'new-branch'
       end


### PR DESCRIPTION
- Pass arguments to shell as an array

It's best practice is to avoid passing interpolated strings to shell commands.

Also add test coverage for Open3 execution!
