### PR TITLE
cleanup exec args

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ so they are available without learning any new commands!
 $ gem install gitx
 ```
 
-### Global Options
-* `--trace` or `-v` = verbose output for debugging commands
-* `--pretend` or `-p` = dry run commands and do not actually invoke operations
-
 ## git start <new_branch_name (optional)>
 
 update local repository with latest upstream changes and create a new feature branch

--- a/lib/gitx/cli/base_command.rb
+++ b/lib/gitx/cli/base_command.rb
@@ -13,11 +13,6 @@ module Gitx
 
       add_runtime_options!
 
-      method_option :trace, type: :boolean, aliases: '-v'
-      def initialize(*args)
-        super(*args)
-      end
-
       private
 
       def repo
@@ -29,7 +24,7 @@ module Gitx
 
       def run_cmd(*cmd)
         executor.execute(*cmd) do |output|
-          say(output, :yellow) if options[:trace]
+          say(output, :yellow)
         end
       end
 

--- a/lib/gitx/cli/base_command.rb
+++ b/lib/gitx/cli/base_command.rb
@@ -2,6 +2,7 @@ require 'thor'
 require 'pathname'
 require 'rugged'
 require 'gitx'
+require 'gitx/executor'
 
 module Gitx
   module Cli
@@ -26,12 +27,18 @@ module Gitx
         end
       end
 
+      def run_cmd(*cmd)
+        executor.execute(*cmd) do |output|
+          say(output, :yellow) if options[:trace]
+        end
+      end
+
       def run_git_cmd(*cmd)
         run_cmd('git', *cmd)
       end
 
       def checkout_branch(branch_name)
-        run_cmd "git checkout #{branch_name}"
+        run_git_cmd 'checkout', branch_name
       end
 
       # lookup the current branch of the repo
@@ -54,6 +61,10 @@ module Gitx
 
       def config
         @configuration ||= Gitx::Configuration.new(repo.workdir)
+      end
+
+      def executor
+        @executor ||= Gitx::Executor.new
       end
     end
   end

--- a/lib/gitx/cli/base_command.rb
+++ b/lib/gitx/cli/base_command.rb
@@ -49,11 +49,6 @@ module Gitx
         fail "Cannot #{action} reserved branch" if config.reserved_branch?(branch) || config.aggregate_branch?(branch)
       end
 
-      # helper to invoke other CLI commands
-      def execute_command(command_class, method, args = [])
-        command_class.new.send(method, *args)
-      end
-
       def config
         @configuration ||= Gitx::Configuration.new(repo.workdir)
       end

--- a/lib/gitx/cli/buildtag_command.rb
+++ b/lib/gitx/cli/buildtag_command.rb
@@ -10,8 +10,8 @@ module Gitx
       method_option :message, type: :string, aliases: '-m', desc: 'message to attach to the buildtag'
       def buildtag
         fail "Branch must be one of the supported taggable branches: #{config.taggable_branches}" unless config.taggable_branch?(branch_name)
-        run_cmd "git tag #{git_tag} -a -m '#{label}'"
-        run_cmd "git push origin #{git_tag}"
+        run_git_cmd 'tag', git_tag, '--annotate', '--message', label
+        run_git_cmd 'push', 'origin', git_tag
       end
 
       private

--- a/lib/gitx/cli/cleanup_command.rb
+++ b/lib/gitx/cli/cleanup_command.rb
@@ -8,16 +8,16 @@ module Gitx
       desc 'cleanup', 'Cleanup branches that have been merged into master from the repo'
       def cleanup
         checkout_branch config.base_branch
-        run_cmd 'git pull'
-        run_cmd 'git remote prune origin'
+        run_git_cmd 'pull'
+        run_git_cmd 'remote', 'prune', 'origin'
 
         say 'Deleting local and remote branches that have been merged into '
         say config.base_branch, :green
         merged_branches(remote: true).each do |branch|
-          run_cmd "git push origin --delete #{branch}"
+          run_git_cmd 'push', 'origin', '--delete', branch
         end
         merged_branches(remote: false).each do |branch|
-          run_cmd "git branch -d #{branch}"
+          run_git_cmd 'branch', '--delete', branch
         end
       end
 
@@ -26,9 +26,9 @@ module Gitx
       # @return list of branches that have been merged
       def merged_branches(options = {})
         args = []
-        args << '-r' if options[:remote]
+        args << '--remote' if options[:remote]
         args << '--merged'
-        output = run_cmd("git branch #{args.join(' ')}").split("\n")
+        output = run_git_cmd('branch', *args).split("\n")
         branches = output.map do |branch|
           branch = branch.gsub(/\*/, '').strip.split(' ').first
           branch = branch.split('/').last if options[:remote]

--- a/lib/gitx/cli/integrate_command.rb
+++ b/lib/gitx/cli/integrate_command.rb
@@ -47,11 +47,11 @@ module Gitx
         commit_message = "[gitx] Integrating #{branch} into #{integration_branch}"
         commit_message += " (Pull request ##{pull_request.number})" if pull_request
         begin
-          run_cmd %Q(git merge --no-ff -m "#{commit_message}" #{branch})
+          run_git_cmd 'merge', '--no-ff', '--message', commit_message, branch
         rescue
           raise MergeError, "Merge conflict occurred.  Please fix merge conflict and rerun command with --resume #{branch} flag"
         end
-        run_cmd 'git push origin HEAD'
+        run_git_cmd 'push', 'origin', 'HEAD'
       end
 
       def feature_branch_name
@@ -67,8 +67,8 @@ module Gitx
       # nuke local branch and pull fresh version from remote repo
       def fetch_remote_branch(target_branch)
         create_remote_branch(target_branch) unless remote_branch_exists?(target_branch)
-        run_cmd 'git fetch origin'
-        run_cmd "git branch -D #{target_branch}", allow_failure: true
+        run_git_cmd 'fetch', 'origin'
+        run_git_cmd('branch', '--delete', '--force', target_branch) rescue Gitx::Executor::ExecutionError
         checkout_branch target_branch
       end
 
@@ -86,7 +86,7 @@ module Gitx
 
       def create_remote_branch(target_branch)
         repo.create_branch(target_branch, config.base_branch)
-        run_cmd "git push origin #{target_branch}:#{target_branch}"
+        run_git_cmd 'push', 'origin', "#{target_branch}:#{target_branch}"
       end
     end
   end

--- a/lib/gitx/cli/integrate_command.rb
+++ b/lib/gitx/cli/integrate_command.rb
@@ -16,12 +16,7 @@ module Gitx
         branch = feature_branch_name
         print_message(branch, integration_branch)
 
-        begin
-          execute_command(UpdateCommand, :update)
-        rescue
-          raise MergeError, 'Merge conflict occurred.  Please fix merge conflict and rerun the integrate command'
-        end
-
+        run_git_cmd 'update'
         pull_request = pull_request_for_branch(branch)
         integrate_branch(branch, integration_branch, pull_request) unless options[:resume]
         checkout_branch branch

--- a/lib/gitx/cli/nuke_command.rb
+++ b/lib/gitx/cli/nuke_command.rb
@@ -25,8 +25,7 @@ module Gitx
         run_git_cmd('branch', '--delete', '--force', bad_branch) rescue Gitx::Executor::ExecutionError
         run_git_cmd('push', 'origin', '--delete', bad_branch) rescue Gitx::Executor::ExecutionError
         run_git_cmd 'checkout', '-b', bad_branch, last_known_good_tag
-        run_git_cmd 'push', 'origin', bad_branch
-        run_git_cmd 'branch', '--set-upstream-to', "origin/#{bad_branch}"
+        run_git_cmd 'share'
         checkout_branch config.base_branch
       end
 

--- a/lib/gitx/cli/release_command.rb
+++ b/lib/gitx/cli/release_command.rb
@@ -1,7 +1,6 @@
 require 'thor'
 require 'gitx'
 require 'gitx/cli/base_command'
-require 'gitx/cli/update_command'
 require 'gitx/github'
 
 module Gitx
@@ -17,7 +16,7 @@ module Gitx
         branch ||= current_branch.name
         assert_not_protected_branch!(branch, 'release')
         checkout_branch(branch)
-        execute_command(UpdateCommand, :update)
+        run_git_cmd 'update'
 
         pull_request = find_or_create_pull_request(branch)
         return unless confirm_branch_status?(branch)

--- a/lib/gitx/cli/release_command.rb
+++ b/lib/gitx/cli/release_command.rb
@@ -23,9 +23,9 @@ module Gitx
         return unless confirm_branch_status?(branch)
 
         checkout_branch config.base_branch
-        run_cmd "git pull origin #{config.base_branch}"
-        run_cmd %Q(git merge --no-ff -m "[gitx] Releasing #{branch} to #{config.base_branch} (Pull request ##{pull_request.number})" #{branch})
-        run_cmd 'git push origin HEAD'
+        run_git_cmd 'pull', 'origin', config.base_branch
+        run_git_cmd 'merge', '--no-ff', '--message', "[gitx] Releasing #{branch} to #{config.base_branch} (Pull request ##{pull_request.number})", branch
+        run_git_cmd 'push', 'origin', 'HEAD'
 
         after_release
       end

--- a/lib/gitx/cli/review_command.rb
+++ b/lib/gitx/cli/review_command.rb
@@ -50,7 +50,7 @@ module Gitx
         reject_pull_request(pull_request) if options[:reject]
         assign_pull_request(pull_request) if options[:assignee]
 
-        run_cmd "open #{pull_request.html_url}" if options[:open]
+        run_cmd('open', pull_request.html_url) if options[:open]
       end
 
       private

--- a/lib/gitx/cli/share_command.rb
+++ b/lib/gitx/cli/share_command.rb
@@ -7,8 +7,8 @@ module Gitx
     class ShareCommand < BaseCommand
       desc 'share', 'Share the current branch in the remote repository'
       def share
-        run_cmd "git push origin #{current_branch.name}"
-        run_cmd "git branch --set-upstream-to origin/#{current_branch.name}"
+        run_git_cmd 'push', 'origin', current_branch.name
+        run_git_cmd 'branch', '--set-upstream-to', "origin/#{current_branch.name}"
       end
     end
   end

--- a/lib/gitx/cli/share_command.rb
+++ b/lib/gitx/cli/share_command.rb
@@ -8,7 +8,7 @@ module Gitx
       desc 'share', 'Share the current branch in the remote repository'
       def share
         run_git_cmd 'push', 'origin', current_branch.name
-        run_git_cmd 'branch', '--set-upstream-to', "origin/#{current_branch.name}"
+        run_git_cmd 'track'
       end
     end
   end

--- a/lib/gitx/cli/track_command.rb
+++ b/lib/gitx/cli/track_command.rb
@@ -7,7 +7,7 @@ module Gitx
     class TrackCommand < BaseCommand
       desc 'track', 'set the current branch to track the remote branch with the same name'
       def track
-        run_cmd "git branch --set-upstream-to origin/#{current_branch.name}"
+        run_git_cmd 'branch', '--set-upstream-to', "origin/#{current_branch.name}"
       end
     end
   end

--- a/lib/gitx/cli/update_command.rb
+++ b/lib/gitx/cli/update_command.rb
@@ -14,13 +14,13 @@ module Gitx
 
         update_branch(current_branch.name) if remote_branch_exists?(current_branch.name)
         update_branch(config.base_branch)
-        run_cmd 'git push origin HEAD'
+        run_git_cmd 'push', 'origin', 'HEAD'
       end
 
       private
 
       def update_branch(branch)
-        run_cmd "git pull origin #{branch}"
+        run_git_cmd 'pull', 'origin', branch
       rescue
         raise MergeError, 'Merge Conflict Occurred. Please fix merge conflict and rerun the update command'
       end

--- a/lib/gitx/cli/update_command.rb
+++ b/lib/gitx/cli/update_command.rb
@@ -14,7 +14,7 @@ module Gitx
 
         update_branch(current_branch.name) if remote_branch_exists?(current_branch.name)
         update_branch(config.base_branch)
-        run_git_cmd 'push', 'origin', 'HEAD'
+        run_git_cmd 'share'
       end
 
       private
@@ -22,7 +22,7 @@ module Gitx
       def update_branch(branch)
         run_git_cmd 'pull', 'origin', branch
       rescue
-        raise MergeError, 'Merge Conflict Occurred. Please fix merge conflict and rerun the update command'
+        raise MergeError, 'Merge conflict occurred. Please fix merge conflict and rerun the command'
       end
 
       def remote_branch_exists?(branch)

--- a/lib/gitx/executor.rb
+++ b/lib/gitx/executor.rb
@@ -1,0 +1,26 @@
+require 'open3'
+
+module Gitx
+  class Executor
+    ExecutionError = Class.new(StandardError)
+
+    # execute a shell command and raise an error if non-zero exit code is returned
+    # return the string output from the command
+    # block argument is passed all output from the executed thread
+    def execute(*cmd)
+      yield "$ #{cmd.join(' ')}" if block_given?
+      output = ''
+
+      Open3.popen2e(*cmd) do |stdin, stdout_err, wait_thread|
+        while line = stdout_err.gets
+          output << line
+          yield line if block_given?
+        end
+
+        exit_status = wait_thread.value
+        fail ExecutionError, "#{cmd.join(' ')} failed" unless exit_status.success?
+      end
+      output
+    end
+  end
+end

--- a/lib/gitx/extensions/thor.rb
+++ b/lib/gitx/extensions/thor.rb
@@ -1,27 +1,5 @@
-require 'open3'
-
 class Thor
   module Actions
-    # execute a shell command and raise an error if non-zero exit code is returned
-    # return the string output from the command
-    def run_cmd(*args)
-      options = args.last.is_a?(Hash) ? args.pop : {}
-      cmd = args
-      say "$ #{cmd.join(' ')}", :yellow
-      output = ''
-
-      Open3.popen2e(*cmd) do |stdin, stdout_err, wait_thr|
-        while line = stdout_err.gets
-          say(line, :yellow) if options[:trace]
-          output << line
-        end
-
-        exit_status = wait_thr.value
-        fail "#{cmd.join(' ')} failed" unless exit_status.success? || options[:allow_failure]
-      end
-      output
-    end
-
     # launch configured editor to retreive message/string
     # see http://osdir.com/ml/ruby-talk/2010-06/msg01424.html
     # see https://gist.github.com/rkumar/456809

--- a/lib/gitx/github.rb
+++ b/lib/gitx/github.rb
@@ -73,7 +73,7 @@ module Gitx
     end
 
     def pull_request_body(branch)
-      changelog = run_cmd("git log #{config.base_branch}...#{branch} --reverse --no-merges --pretty=format:'* %B'")
+      changelog = run_git_cmd('log', "#{config.base_branch}...#{branch}", '--reverse', '--no-merges', "--pretty=format:'* %B'")
       description = options[:description]
 
       description_template = []

--- a/lib/gitx/github.rb
+++ b/lib/gitx/github.rb
@@ -1,7 +1,6 @@
 require 'octokit'
 require 'fileutils'
 require 'yaml'
-require 'gitx/cli/update_command'
 
 module Gitx
   module Github
@@ -23,7 +22,7 @@ module Gitx
       pull_request = find_pull_request(branch)
       pull_request ||= begin
         checkout_branch(branch)
-        execute_command(Gitx::Cli::UpdateCommand, :update)
+        run_git_cmd 'update'
         pull_request = create_pull_request(branch)
         say 'Created pull request: '
         say pull_request.html_url, :green

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.21.3'
+  VERSION = '2.21.4'
 end

--- a/spec/gitx/cli/buildtag_command_spec.rb
+++ b/spec/gitx/cli/buildtag_command_spec.rb
@@ -10,6 +10,7 @@ describe Gitx::Cli::BuildtagCommand do
     }
   end
   let(:cli) { described_class.new(args, options, config) }
+  let(:executor) { cli.send(:executor) }
   let(:branch) { double('fake branch', name: 'feature-branch') }
 
   before do
@@ -40,8 +41,8 @@ describe Gitx::Cli::BuildtagCommand do
       end
       before do
         Timecop.freeze(Time.utc(2013, 10, 30, 10, 21, 28)) do
-          expect(cli).to receive(:run_cmd).with("git tag build-master-2013-10-30-10-21-28 -a -m '[gitx] buildtag for master'").ordered
-          expect(cli).to receive(:run_cmd).with('git push origin build-master-2013-10-30-10-21-28').ordered
+          expect(executor).to receive(:execute).with('git', 'tag', 'build-master-2013-10-30-10-21-28', '--annotate', '--message', '[gitx] buildtag for master').ordered
+          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'build-master-2013-10-30-10-21-28').ordered
           cli.buildtag
         end
       end
@@ -58,8 +59,8 @@ describe Gitx::Cli::BuildtagCommand do
       end
       before do
         Timecop.freeze(Time.utc(2013, 10, 30, 10, 21, 28)) do
-          expect(cli).to receive(:run_cmd).with("git tag build-master-2013-10-30-10-21-28 -a -m 'custom git commit message'").ordered
-          expect(cli).to receive(:run_cmd).with('git push origin build-master-2013-10-30-10-21-28').ordered
+          expect(executor).to receive(:execute).with('git', 'tag', 'build-master-2013-10-30-10-21-28', '--annotate', '--message', 'custom git commit message').ordered
+          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'build-master-2013-10-30-10-21-28').ordered
           cli.buildtag
         end
       end

--- a/spec/gitx/cli/cleanup_command_spec.rb
+++ b/spec/gitx/cli/cleanup_command_spec.rb
@@ -9,8 +9,11 @@ describe Gitx::Cli::CleanupCommand do
       pretend: true
     }
   end
-  let(:cli) { Gitx::Cli::CleanupCommand.new(args, options, config) }
+  let(:cli) { described_class.new(args, options, config) }
+  let(:executor) { cli.send(:executor) }
   let(:branch) { double('fake branch', name: 'feature-branch') }
+  let(:remote_branches) { 'merged-remote-feature' }
+  let(:local_branches) { 'merged-local-feature' }
 
   before do
     allow(cli).to receive(:current_branch).and_return(branch)
@@ -20,13 +23,13 @@ describe Gitx::Cli::CleanupCommand do
     before do
       allow(cli).to receive(:say)
 
-      expect(cli).to receive(:run_cmd).with('git checkout master').ordered
-      expect(cli).to receive(:run_cmd).with('git pull').ordered
-      expect(cli).to receive(:run_cmd).with('git remote prune origin').ordered
-      expect(cli).to receive(:run_cmd).with('git branch -r --merged').and_return('merged-remote-feature').ordered
-      expect(cli).to receive(:run_cmd).with('git push origin --delete merged-remote-feature').ordered
-      expect(cli).to receive(:run_cmd).with('git branch --merged').and_return('merged-local-feature').ordered
-      expect(cli).to receive(:run_cmd).with('git branch -d merged-local-feature').ordered
+      expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+      expect(executor).to receive(:execute).with('git', 'pull').ordered
+      expect(executor).to receive(:execute).with('git', 'remote', 'prune', 'origin').ordered
+      expect(executor).to receive(:execute).with('git', 'branch', '--remote', '--merged').and_return(remote_branches).ordered
+      expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'merged-remote-feature').ordered
+      expect(executor).to receive(:execute).with('git', 'branch', '--merged').and_return(local_branches).ordered
+      expect(executor).to receive(:execute).with('git', 'branch', '--delete', 'merged-local-feature').ordered
 
       cli.cleanup
     end

--- a/spec/gitx/cli/integrate_command_spec.rb
+++ b/spec/gitx/cli/integrate_command_spec.rb
@@ -30,8 +30,7 @@ describe Gitx::Cli::IntegrateCommand do
     context 'when integration branch is ommitted and remote branch exists' do
       let(:remote_branch_names) { ['origin/staging'] }
       before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'staging').ordered
@@ -52,8 +51,7 @@ describe Gitx::Cli::IntegrateCommand do
       let(:local_branch_names) { ['master'] }
       let(:remote_branch_names) { ['origin/staging'] }
       before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'staging').ordered
@@ -82,9 +80,10 @@ describe Gitx::Cli::IntegrateCommand do
       let(:changelog) { '2013-01-01 did some stuff' }
       before do
         allow(cli).to receive(:ask_editor).and_return('description')
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update).twice
 
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'log', 'master...feature-branch', '--reverse', '--no-merges', "--pretty=format:'* %B'").and_return(changelog).ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging').ordered
@@ -109,10 +108,9 @@ describe Gitx::Cli::IntegrateCommand do
     context 'when staging branch does not exist remotely' do
       let(:remote_branch_names) { [] }
       before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
         expect(repo).to receive(:create_branch).with('staging', 'master')
 
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'staging:staging').ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging').and_raise(Gitx::Executor::ExecutionError).ordered
@@ -132,8 +130,7 @@ describe Gitx::Cli::IntegrateCommand do
     context 'when integration branch == prototype and remote branch exists' do
       let(:remote_branch_names) { ['origin/prototype'] }
       before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'prototype').ordered
@@ -154,22 +151,10 @@ describe Gitx::Cli::IntegrateCommand do
         expect { cli.integrate('some-other-branch') }.to raise_error(/Invalid aggregate branch: some-other-branch must be one of supported aggregate branches/)
       end
     end
-    context 'when merge conflicts occur during the Gitx::Cli::UpdateCommand execution' do
-      let(:remote_branch_names) { ['origin/staging'] }
-      before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update).and_raise(Gitx::Cli::BaseCommand::MergeError)
-
-        expect { cli.integrate }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge conflict occurred.  Please fix merge conflict and rerun the integrate command')
-      end
-      it 'raises a helpful error' do
-        should meet_expectations
-      end
-    end
     context 'when merge conflicts occur with the integrate command' do
       let(:remote_branch_names) { ['origin/staging'] }
       before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'staging').ordered
@@ -191,8 +176,7 @@ describe Gitx::Cli::IntegrateCommand do
       end
       let(:repo) { cli.send(:repo) }
       before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).not_to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging')
         expect(executor).not_to receive(:execute).with('git', 'push', 'origin', 'HEAD')
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch')
@@ -213,7 +197,7 @@ describe Gitx::Cli::IntegrateCommand do
       end
       let(:local_branch_names) { ['feature-branch'] }
       before do
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(cli).to receive(:ask).and_return('feature-branch')
 
         expect(executor).not_to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging')

--- a/spec/gitx/cli/nuke_command_spec.rb
+++ b/spec/gitx/cli/nuke_command_spec.rb
@@ -36,8 +36,7 @@ describe Gitx::Cli::NukeCommand do
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'build-master-2013-10-01-01').ordered
-        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'prototype').ordered
-        expect(executor).to receive(:execute).with('git', 'branch', '--set-upstream-to', 'origin/prototype').ordered
+        expect(executor).to receive(:execute).with('git', 'share').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
 
         cli.nuke bad_branch
@@ -60,8 +59,7 @@ describe Gitx::Cli::NukeCommand do
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'build-master-2013-10-01-01').ordered
-        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'prototype').ordered
-        expect(executor).to receive(:execute).with('git', 'branch', '--set-upstream-to', 'origin/prototype').ordered
+        expect(executor).to receive(:execute).with('git', 'share').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
 
         cli.nuke 'prototype'
@@ -149,8 +147,7 @@ describe Gitx::Cli::NukeCommand do
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'build-master-2013-10-01-01').ordered
-        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'prototype').ordered
-        expect(executor).to receive(:execute).with('git', 'branch', '--set-upstream-to', 'origin/prototype').ordered
+        expect(executor).to receive(:execute).with('git', 'share').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
 
         cli.nuke 'prototype'

--- a/spec/gitx/cli/release_command_spec.rb
+++ b/spec/gitx/cli/release_command_spec.rb
@@ -34,12 +34,12 @@ describe Gitx::Cli::ReleaseCommand do
     context 'when user confirms release and pull request exists with non-success status' do
       before do
         expect(repo).to receive(:workdir).and_return(temp_dir)
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
 
         expect(cli).to receive(:yes?).with('Release feature-branch to master? (y/n)', :green).and_return(true)
         expect(cli).to receive(:yes?).with('Branch status is currently: failure.  Proceed with release? (y/n)', :red).and_return(false)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to_not receive(:execute).with('git', 'checkout', 'master')
         expect(executor).to_not receive(:execute).with('git', 'pull', 'origin', 'master')
         expect(executor).to_not receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch')
@@ -57,12 +57,11 @@ describe Gitx::Cli::ReleaseCommand do
       before do
         expect(repo).to receive(:workdir).and_return(temp_dir)
 
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
@@ -88,12 +87,11 @@ describe Gitx::Cli::ReleaseCommand do
         File.open(File.join(temp_dir, '.gitx.yml'), 'w') do |f|
           f.puts gitx_config.to_yaml
         end
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
-
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
@@ -111,12 +109,12 @@ describe Gitx::Cli::ReleaseCommand do
     context 'when target_branch is not nil and user confirms release and pull request exists with success status' do
       before do
         expect(repo).to receive(:workdir).and_return(temp_dir)
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
 
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
@@ -147,13 +145,13 @@ describe Gitx::Cli::ReleaseCommand do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         allow(cli).to receive(:ask_editor).and_return('description')
 
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update).twice
-
         expect(cli).to receive(:yes?).with('Release feature-branch to master? (y/n)', :green).and_return(true)
         expect(cli).to receive(:yes?).with('Branch status is currently: pending.  Proceed with release? (y/n)', :red).and_return(true)
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'log', 'master...feature-branch', '--reverse', '--no-merges', "--pretty=format:'* %B'").and_return('2013-01-01 did some stuff').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
@@ -181,12 +179,12 @@ describe Gitx::Cli::ReleaseCommand do
       end
       before do
         expect(repo).to receive(:workdir).and_return(temp_dir)
-        expect(cli).to receive(:execute_command).with(Gitx::Cli::UpdateCommand, :update)
 
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered

--- a/spec/gitx/cli/release_command_spec.rb
+++ b/spec/gitx/cli/release_command_spec.rb
@@ -13,6 +13,7 @@ describe Gitx::Cli::ReleaseCommand do
   let(:branch) { double('fake branch', name: 'feature-branch') }
   let(:authorization_token) { '123123' }
   let(:repo) { cli.send(:repo) }
+  let(:executor) { cli.send(:executor) }
 
   before do
     allow(cli).to receive(:current_branch).and_return(branch)
@@ -22,7 +23,7 @@ describe Gitx::Cli::ReleaseCommand do
     context 'when user rejects release' do
       before do
         expect(cli).to receive(:yes?).and_return(false)
-        expect(cli).to_not receive(:run_cmd)
+        expect(executor).to_not receive(:execute)
 
         cli.release
       end
@@ -39,10 +40,10 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).with('Branch status is currently: failure.  Proceed with release? (y/n)', :red).and_return(false)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
-        expect(cli).to_not receive(:run_cmd).with('git checkout master')
-        expect(cli).to_not receive(:run_cmd).with('git pull origin master')
-        expect(cli).to_not receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch')
-        expect(cli).to_not receive(:run_cmd).with('git push origin HEAD')
+        expect(executor).to_not receive(:execute).with('git', 'checkout', 'master')
+        expect(executor).to_not receive(:execute).with('git', 'pull', 'origin', 'master')
+        expect(executor).to_not receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch')
+        expect(executor).to_not receive(:execute).with('git', 'push', 'origin', 'HEAD')
 
         VCR.use_cassette('pull_request_does_exist_with_failure_status') do
           cli.release
@@ -61,12 +62,12 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
-        expect(cli).to receive(:run_cmd).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
+        expect(executor).to receive(:execute).with('git integrate').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.release
@@ -92,12 +93,12 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
-        expect(cli).to receive(:run_cmd).with('echo hello').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
+        expect(executor).to receive(:execute).with('echo hello').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.release
@@ -115,12 +116,12 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
-        expect(cli).to receive(:run_cmd).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
+        expect(executor).to receive(:execute).with('git integrate').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.release 'feature-branch'
@@ -151,14 +152,14 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).with('Release feature-branch to master? (y/n)', :green).and_return(true)
         expect(cli).to receive(:yes?).with('Branch status is currently: pending.  Proceed with release? (y/n)', :red).and_return(true)
 
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %B'").and_return('2013-01-01 did some stuff').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
-        expect(cli).to receive(:run_cmd).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'log', 'master...feature-branch', '--reverse', '--no-merges', "--pretty=format:'* %B'").and_return('2013-01-01 did some stuff').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
+        expect(executor).to receive(:execute).with('git integrate').ordered
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
         VCR.use_cassette('pull_request_does_not_exist') do
@@ -185,13 +186,13 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git checkout master').ordered
-        expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git merge --no-ff -m "[gitx] Releasing feature-branch to master (Pull request #10)" feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
-        expect(cli).to receive(:run_cmd).with('git integrate').ordered
-        expect(cli).to receive(:run_cmd).with('git cleanup').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Releasing feature-branch to master (Pull request #10)', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
+        expect(executor).to receive(:execute).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git cleanup').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.release

--- a/spec/gitx/cli/review_command_spec.rb
+++ b/spec/gitx/cli/review_command_spec.rb
@@ -10,6 +10,7 @@ describe Gitx::Cli::ReviewCommand do
     }
   end
   let(:cli) { described_class.new(args, options, config) }
+  let(:executor) { cli.send(:executor) }
   let(:repo) { double('fake repo', config: repo_config, workdir: repo_workdir) }
   let(:repo_workdir) { File.expand_path(File.join(__dir__, '../../../')) }
   let(:repo_config) do
@@ -45,8 +46,8 @@ describe Gitx::Cli::ReviewCommand do
         expect(Gitx::Cli::UpdateCommand).to receive(:new).and_return(fake_update_command)
 
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %B'").and_return(changelog).ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'log', 'master...feature-branch', '--reverse', '--no-merges', "--pretty=format:'* %B'").and_return(changelog).ordered
         expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return('description')
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
@@ -82,8 +83,8 @@ describe Gitx::Cli::ReviewCommand do
         expect(Gitx::Cli::UpdateCommand).to receive(:new).and_return(fake_update_command)
 
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
-        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %B'").and_return(changelog).ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'log', 'master...feature-branch', '--reverse', '--no-merges', "--pretty=format:'* %B'").and_return(changelog).ordered
         expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return(pull_request_description)
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls')
@@ -151,7 +152,7 @@ describe Gitx::Cli::ReviewCommand do
       let(:authorization_token) { '123123' }
       before do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
-        expect(cli).to receive(:run_cmd).with('open https://path/to/html/pull/request').ordered
+        expect(executor).to receive(:execute).with('open', 'https://path/to/html/pull/request').ordered
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.review
         end

--- a/spec/gitx/cli/review_command_spec.rb
+++ b/spec/gitx/cli/review_command_spec.rb
@@ -43,10 +43,9 @@ describe Gitx::Cli::ReviewCommand do
       end
       let(:changelog) { "* old commit\n\n* new commit" }
       before do
-        expect(Gitx::Cli::UpdateCommand).to receive(:new).and_return(fake_update_command)
-
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'log', 'master...feature-branch', '--reverse', '--no-merges', "--pretty=format:'* %B'").and_return(changelog).ordered
         expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return('description')
 
@@ -80,10 +79,9 @@ describe Gitx::Cli::ReviewCommand do
       let(:changelog) { "* old commit\n\n* new commit" }
       let(:pull_request_description) { 'description' }
       before do
-        expect(Gitx::Cli::UpdateCommand).to receive(:new).and_return(fake_update_command)
-
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'log', 'master...feature-branch', '--reverse', '--no-merges', "--pretty=format:'* %B'").and_return(changelog).ordered
         expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return(pull_request_description)
 

--- a/spec/gitx/cli/share_command_spec.rb
+++ b/spec/gitx/cli/share_command_spec.rb
@@ -22,7 +22,7 @@ describe Gitx::Cli::ShareCommand do
       allow(cli).to receive(:say)
 
       expect(executor).to receive(:execute).with('git', 'push', 'origin', 'feature-branch').ordered
-      expect(executor).to receive(:execute).with('git', 'branch', '--set-upstream-to', 'origin/feature-branch').ordered
+      expect(executor).to receive(:execute).with('git', 'track').ordered
 
       cli.share
     end

--- a/spec/gitx/cli/share_command_spec.rb
+++ b/spec/gitx/cli/share_command_spec.rb
@@ -9,7 +9,8 @@ describe Gitx::Cli::ShareCommand do
       pretend: true
     }
   end
-  let(:cli) { Gitx::Cli::ShareCommand.new(args, options, config) }
+  let(:cli) { described_class.new(args, options, config) }
+  let(:executor) { cli.send(:executor) }
   let(:branch) { double('fake branch', name: 'feature-branch') }
 
   before do
@@ -20,8 +21,8 @@ describe Gitx::Cli::ShareCommand do
     before do
       allow(cli).to receive(:say)
 
-      expect(cli).to receive(:run_cmd).with('git push origin feature-branch').ordered
-      expect(cli).to receive(:run_cmd).with('git branch --set-upstream-to origin/feature-branch').ordered
+      expect(executor).to receive(:execute).with('git', 'push', 'origin', 'feature-branch').ordered
+      expect(executor).to receive(:execute).with('git', 'branch', '--set-upstream-to', 'origin/feature-branch').ordered
 
       cli.share
     end

--- a/spec/gitx/cli/start_command_spec.rb
+++ b/spec/gitx/cli/start_command_spec.rb
@@ -11,15 +11,13 @@ describe Gitx::Cli::StartCommand do
   end
   let(:cli) { described_class.new(args, options, config) }
   let(:repo) { cli.send(:repo) }
-  let(:exit_value) { double(:exit_value, success?: true) }
-  let(:thread) { double(:thread, value: exit_value) }
-  let(:stdoutput) { StringIO.new('') }
+  let(:executor) { cli.send(:executor) }
 
   describe '#start' do
     context 'when user inputs branch that is valid' do
       before do
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
+        expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -34,7 +32,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
+        expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -49,7 +47,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
+        expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -67,7 +65,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
+        expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -85,7 +83,7 @@ describe Gitx::Cli::StartCommand do
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
+        expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
@@ -103,10 +101,10 @@ describe Gitx::Cli::StartCommand do
       end
       before do
         expect(cli).to receive(:checkout_branch).with('master').ordered
-        expect(Open3).to receive(:popen2e).with('git', 'pull').and_yield(nil, stdoutput, thread).ordered
+        expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
-        expect(Open3).to receive(:popen2e).with('git', 'commit', '--allow-empty', '--message', 'Starting work on new-branch (Issue #10)').and_yield(nil, stdoutput, thread).ordered
+        expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', 'Starting work on new-branch (Issue #10)').ordered
 
         cli.start 'new-branch'
       end

--- a/spec/gitx/cli/track_command_spec.rb
+++ b/spec/gitx/cli/track_command_spec.rb
@@ -9,7 +9,8 @@ describe Gitx::Cli::TrackCommand do
       pretend: true
     }
   end
-  let(:cli) { Gitx::Cli::TrackCommand.new(args, options, config) }
+  let(:cli) { described_class.new(args, options, config) }
+  let(:executor) { cli.send(:executor) }
   let(:branch) { double('fake branch', name: 'feature-branch') }
 
   before do
@@ -20,7 +21,7 @@ describe Gitx::Cli::TrackCommand do
     before do
       allow(cli).to receive(:say)
 
-      expect(cli).to receive(:run_cmd).with('git branch --set-upstream-to origin/feature-branch').ordered
+      expect(executor).to receive(:execute).with('git', 'branch', '--set-upstream-to', 'origin/feature-branch').ordered
 
       cli.track
     end

--- a/spec/gitx/cli/update_command_spec.rb
+++ b/spec/gitx/cli/update_command_spec.rb
@@ -9,9 +9,10 @@ describe Gitx::Cli::UpdateCommand do
       pretend: true
     }
   end
-  let(:cli) { Gitx::Cli::UpdateCommand.new(args, options, config) }
+  let(:cli) { described_class.new(args, options, config) }
   let(:branch) { double('fake branch', name: 'feature-branch') }
   let(:repo) { cli.send(:repo) }
+  let(:executor) { cli.send(:executor) }
   let(:remote_branch_names) { ['origin/feature-branch'] }
 
   before do
@@ -26,9 +27,9 @@ describe Gitx::Cli::UpdateCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(cli).to receive(:run_cmd).with('git pull origin feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
-        expect(cli).to receive(:run_cmd).with('git push origin HEAD').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
 
         cli.update
       end
@@ -40,7 +41,7 @@ describe Gitx::Cli::UpdateCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(cli).to receive(:run_cmd).with('git pull origin feature-branch').and_raise('merge error').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').and_raise('merge error').ordered
 
         expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge Conflict Occurred. Please fix merge conflict and rerun the update command')
       end
@@ -52,8 +53,8 @@ describe Gitx::Cli::UpdateCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(cli).to receive(:run_cmd).with('git pull origin feature-branch').ordered
-        expect(cli).to receive(:run_cmd).with('git pull origin master').and_raise('merge error occurred').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').and_raise('merge error occurred').ordered
 
         expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge Conflict Occurred. Please fix merge conflict and rerun the update command')
       end
@@ -66,8 +67,8 @@ describe Gitx::Cli::UpdateCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(cli).not_to receive(:run_cmd).with('git pull origin feature-branch')
-        expect(cli).to receive(:run_cmd).with('git pull origin master').ordered
+        expect(executor).not_to receive(:execute).with('git', 'pull', 'origin', 'feature-branch')
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
 
         cli.update
       end

--- a/spec/gitx/cli/update_command_spec.rb
+++ b/spec/gitx/cli/update_command_spec.rb
@@ -29,7 +29,7 @@ describe Gitx::Cli::UpdateCommand do
 
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
+        expect(executor).to receive(:execute).with('git', 'share').ordered
 
         cli.update
       end
@@ -43,7 +43,7 @@ describe Gitx::Cli::UpdateCommand do
 
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').and_raise('merge error').ordered
 
-        expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge Conflict Occurred. Please fix merge conflict and rerun the update command')
+        expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge conflict occurred. Please fix merge conflict and rerun the command')
       end
       it 'raises error' do
         should meet_expectations
@@ -56,7 +56,7 @@ describe Gitx::Cli::UpdateCommand do
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').and_raise('merge error occurred').ordered
 
-        expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge Conflict Occurred. Please fix merge conflict and rerun the update command')
+        expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge conflict occurred. Please fix merge conflict and rerun the command')
       end
       it 'raises error' do
         should meet_expectations

--- a/spec/gitx/executor_spec.rb
+++ b/spec/gitx/executor_spec.rb
@@ -1,0 +1,41 @@
+require 'gitx/executor'
+
+RSpec.describe Gitx::Executor do
+  let(:executor) { described_class.new }
+  let(:exit_value) { double(:exit_value, success?: true) }
+  let(:thread) { double(:thread, value: exit_value) }
+  let(:stdoutput) { StringIO.new('Hello World') }
+  before do
+    expect(Open3).to receive(:popen2e).and_yield(nil, stdoutput, thread)
+  end
+
+  describe '#execute' do
+    context 'when execution is successful and block given' do
+      before do
+        @output = []
+        executor.execute('some', 'command', '--with', '--args') do |output|
+          @output << output
+        end
+      end
+      it 'yields the command and output' do
+        expect(@output).to eq ['$ some command --with --args', 'Hello World']
+      end
+    end
+    context 'when execution is successful' do
+      before do
+        @output = executor.execute('some', 'command', '--with', '--args')
+      end
+      it 'returns the output' do
+        expect(@output).to eq 'Hello World'
+      end
+    end
+    context 'when execution is not sucessful' do
+      let(:exit_value) { double(:exit_value, success?: false) }
+      it 'raises ExecutionError' do
+        expect do
+          executor.execute('some', 'bad', 'command')
+        end.to raise_error Gitx::Executor::ExecutionError
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What changed?
- Refactor shell commands to use array parameters

Fix #35
Fix #36

Extract executor for executing shell commands
