### PR TITLE
build prefix

### DIFF
--- a/lib/gitx/cli/buildtag_command.rb
+++ b/lib/gitx/cli/buildtag_command.rb
@@ -5,13 +5,16 @@ require 'gitx/cli/base_command'
 module Gitx
   module Cli
     class BuildtagCommand < BaseCommand
+      BUILD_TAG_PREFIX = 'builds'.freeze
+      BUILD_TAG_SEPARATOR = '/'.freeze
+
       desc 'buildtag', 'create a tag for the current build and push it back to origin (supports Travis CI and Codeship)'
       method_option :branch, type: :string, aliases: '-b', desc: 'branch name for build tag'
       method_option :message, type: :string, aliases: '-m', desc: 'message to attach to the buildtag'
       def buildtag
         raise "Branch must be one of the supported taggable branches: #{config.taggable_branches}" unless config.taggable_branch?(branch_name)
-        run_git_cmd 'tag', git_tag, '--annotate', '--message', label
-        run_git_cmd 'push', 'origin', git_tag
+        run_git_cmd 'tag', build_tag, '--annotate', '--message', label
+        run_git_cmd 'push', 'origin', build_tag
       end
 
       private
@@ -24,9 +27,16 @@ module Gitx
         options[:message] || "[gitx] buildtag for #{branch_name}"
       end
 
-      def git_tag
-        timestamp = Time.now.utc.strftime '%Y-%m-%d-%H-%M-%S'
-        "build-#{branch_name}-#{timestamp}"
+      def build_tag
+        @buildtag ||= [
+          BUILD_TAG_PREFIX,
+          branch_name,
+          utc_timestamp
+        ].join(BUILD_TAG_SEPARATOR)
+      end
+
+      def utc_timestamp
+        Time.now.utc.strftime '%Y-%m-%d-%H-%M-%S'
       end
     end
   end

--- a/lib/gitx/cli/nuke_command.rb
+++ b/lib/gitx/cli/nuke_command.rb
@@ -1,6 +1,7 @@
 require 'thor'
 require 'gitx'
 require 'gitx/cli/base_command'
+require 'gitx/cli/buildtag_command'
 
 module Gitx
   module Cli
@@ -47,14 +48,15 @@ module Gitx
 
       def current_build_tag(branch)
         last_build_tag = build_tags_for_branch(branch).last
-        raise "No known good tag found for branch: #{branch}.  Verify tag exists via `git tag -l 'build-#{branch}-*'`" unless last_build_tag
+        raise "No known good tag found for branch: #{branch}.  Verify tag exists via `git tag -l`" unless last_build_tag
         last_build_tag
       end
 
       def build_tags_for_branch(branch)
         run_git_cmd 'fetch', '--tags'
-        build_tags = run_git_cmd('tag', '--list', "build-#{branch}-*").split
-        build_tags.sort
+        prefix = [BuildtagCommand::BUILD_TAG_PREFIX, branch].join(BuildtagCommand::BUILD_TAG_SEPARATOR)
+        tags = repo.tags.select { |t| t.name.starts_with?(prefix) }
+        tags.map(&:name).sort
       end
     end
   end

--- a/lib/gitx/extensions/string.rb
+++ b/lib/gitx/extensions/string.rb
@@ -9,4 +9,9 @@ class String
   def blank?
     to_s == ''
   end
+
+  # @see http://apidock.com/rails/ActiveSupport/CoreExtensions/String/StartsEndsWith/starts_with%
+  def starts_with?(prefix)
+    prefix.respond_to?(:to_str) && self[0, prefix.length] == prefix
+  end
 end

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '2.23.2'.freeze
+  VERSION = '3.0.0'.freeze
 end

--- a/spec/gitx/cli/buildtag_command_spec.rb
+++ b/spec/gitx/cli/buildtag_command_spec.rb
@@ -41,8 +41,8 @@ describe Gitx::Cli::BuildtagCommand do
       end
       before do
         Timecop.freeze(Time.utc(2013, 10, 30, 10, 21, 28)) do
-          expect(executor).to receive(:execute).with('git', 'tag', 'build-master-2013-10-30-10-21-28', '--annotate', '--message', '[gitx] buildtag for master').ordered
-          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'build-master-2013-10-30-10-21-28').ordered
+          expect(executor).to receive(:execute).with('git', 'tag', 'builds/master/2013-10-30-10-21-28', '--annotate', '--message', '[gitx] buildtag for master').ordered
+          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'builds/master/2013-10-30-10-21-28').ordered
           cli.buildtag
         end
       end
@@ -59,8 +59,8 @@ describe Gitx::Cli::BuildtagCommand do
       end
       before do
         Timecop.freeze(Time.utc(2013, 10, 30, 10, 21, 28)) do
-          expect(executor).to receive(:execute).with('git', 'tag', 'build-master-2013-10-30-10-21-28', '--annotate', '--message', 'custom git commit message').ordered
-          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'build-master-2013-10-30-10-21-28').ordered
+          expect(executor).to receive(:execute).with('git', 'tag', 'builds/master/2013-10-30-10-21-28', '--annotate', '--message', 'custom git commit message').ordered
+          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'builds/master/2013-10-30-10-21-28').ordered
           cli.buildtag
         end
       end


### PR DESCRIPTION
- Change buildtags to use "folder style" format

Fixes #40

Change from "build-BRANCH_NAME-TIMESTAMP" to
"builds/BRANCH_NAME/TIMESTAMP"
