### PR TITLE
Allow non-numeric issue identifier characters

### DIFF
--- a/lib/gitx/cli/start_command.rb
+++ b/lib/gitx/cli/start_command.rb
@@ -26,7 +26,7 @@ module Gitx
 
       def commit_message(branch_name)
         message = "[gitx] Start work on #{branch_name}"
-        if issue = options[:issue]
+        if (issue = options[:issue])
           issue = issue.dup.prepend('#') if issue =~ /\A\d+\z/
           message += "\n\nConnected to #{issue}"
         end

--- a/lib/gitx/cli/start_command.rb
+++ b/lib/gitx/cli/start_command.rb
@@ -9,7 +9,7 @@ module Gitx
       VALID_BRANCH_NAME_REGEX = /^[A-Za-z0-9\-_]+$/
 
       desc 'start', 'start a new git branch with latest changes from master'
-      method_option :issue, type: :numeric, aliases: '-i', desc: 'Github issue number'
+      method_option :issue, type: :string, aliases: '-i', desc: 'Issue identifier'
       def start(branch_name = nil)
         until valid_new_branch_name?(branch_name)
           branch_name = ask("What would you like to name your branch? (ex: #{EXAMPLE_BRANCH_NAMES.sample})")
@@ -26,7 +26,10 @@ module Gitx
 
       def commit_message(branch_name)
         message = "[gitx] Start work on #{branch_name}"
-        message += "\n\nConnected to ##{options[:issue]}" if options[:issue]
+        if issue = options[:issue]
+          issue = issue.dup.prepend('#') if issue =~ /\A\d+\z/
+          message += "\n\nConnected to #{issue}"
+        end
         message
       end
 

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.1.0'.freeze
 end

--- a/spec/gitx/cli/start_command_spec.rb
+++ b/spec/gitx/cli/start_command_spec.rb
@@ -112,10 +112,10 @@ describe Gitx::Cli::StartCommand do
         should meet_expectations
       end
     end
-    context 'when --issue option is used' do
+    context 'when --issue option is used with a numeric issue ID' do
       let(:options) do
         {
-          issue: 10
+          issue: '10'
         }
       end
       before do
@@ -124,6 +124,25 @@ describe Gitx::Cli::StartCommand do
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', "[gitx] Start work on new-branch\n\nConnected to #10").ordered
+
+        cli.start 'new-branch'
+      end
+      it 'creates empty commit with link to issue id' do
+        should meet_expectations
+      end
+    end
+    context 'when --issue option is used with a non-numeric issue ID' do
+      let(:options) do
+        {
+          issue: 'FOO-123'
+        }
+      end
+      before do
+        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(cli).to receive(:checkout_branch).with('new-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', "[gitx] Start work on new-branch\n\nConnected to FOO-123").ordered
 
         cli.start 'new-branch'
       end


### PR DESCRIPTION
For the `git-start` command, allow issue identifiers for non-numeric issues to be used, in order to support issues from systems other than Github.