### PR TITLE
Simple tweak to make sure output from git release is right

### DIFF
--- a/lib/gitx/cli/release_command.rb
+++ b/lib/gitx/cli/release_command.rb
@@ -11,9 +11,10 @@ module Gitx
       desc 'release', 'release the current branch to production'
       method_option :cleanup, type: :boolean, desc: 'cleanup merged branches after release'
       def release(branch = nil)
-        return unless yes?("Release #{current_branch.name} to #{config.base_branch}? (y/n)", :green)
-
         branch ||= current_branch.name
+        
+        return unless yes?("Release #{branch} to #{config.base_branch}? (y/n)", :green)
+
         assert_not_protected_branch!(branch, 'release')
         checkout_branch(branch)
         run_git_cmd 'update'

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.1.1'.freeze
 end


### PR DESCRIPTION
`release` takes an explicit branch name and does all the right things **except** it was still outputting `current_branch.name` even if that were overridden. So if you were checked out to `master` but said `git release foo-branch` it would say 'Release master to master (y/n)'.