### PR TITLE
Bump rugged to v0.27.10

### DIFF
--- a/gitx.gemspec
+++ b/gitx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'octokit'
-  spec.add_runtime_dependency 'rugged', '~> 0.26.0'
+  spec.add_runtime_dependency 'rugged', '~> 0.27.10'
   spec.add_runtime_dependency 'thor'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
I was playing around with the latest Ubuntu 20.04 this weekend and noticed I couldn't install gitx because rugged couldn't build with the pinned libgit2 v26. Seems like there were some breaking dependencies in newer Ubuntu versions. 

<details><summary>Failed to build with libgit2 v26:</summary>

```
ERROR:  Error installing rugged:
	ERROR: Failed to build gem native extension.

    current directory: /home/jesalg/.rvm/gems/ruby-2.6.3/gems/rugged-0.26.7/ext/rugged
/home/jesalg/.rvm/rubies/ruby-2.6.3/bin/ruby -I /home/jesalg/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0 -r ./siteconf20200426-10615-m8kbxz.rb extconf.rb
checking for gmake... yes
checking for cmake... yes
checking for pkg-config... yes
 -- cmake .. -DBUILD_CLAR=OFF -DTHREADSAFE=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS=-fPIC -DCMAKE_BUILD_TYPE=RelWithDebInfo  
 -- /usr/bin/gmake
checking for -lgit2... yes
checking for git2.h... yes
creating Makefile

current directory: /home/jesalg/.rvm/gems/ruby-2.6.3/gems/rugged-0.26.7/ext/rugged
make "DESTDIR=" clean

current directory: /home/jesalg/.rvm/gems/ruby-2.6.3/gems/rugged-0.26.7/ext/rugged
make "DESTDIR="
compiling rugged.c
rugged.c: In function ‘rugged_exception_raise’:
rugged.c:317:6: warning: function might be candidate for attribute ‘noreturn’ [-Wsuggest-attribute=noreturn]
  317 | void rugged_exception_raise(void)
      |      ^~~~~~~~~~~~~~~~~~~~~~
rugged.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
compiling rugged_backend.c
compiling rugged_blame.c
In file included from /home/jesalg/.rvm/rubies/ruby-2.6.3/include/ruby-2.6.0/ruby.h:33,
                 from rugged.h:16,
                 from rugged_blame.c:8:
In function ‘rb_git_blame_each’,
    inlined from ‘rb_git_blame_each’ at rugged_blame.c:240:14:
/home/jesalg/.rvm/rubies/ruby-2.6.3/include/ruby-2.6.0/ruby/ruby.h:1850:3: error: call to ‘rb_varargs_bad_length’ declared with attribute error:  argument length doesn't match
 1850 |   rb_varargs_bad_length(argc, vargc)), \
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jesalg/.rvm/rubies/ruby-2.6.3/include/ruby-2.6.0/ruby/ruby.h:2603:6: note: in expansion of macro ‘rb_varargs_argc_check’
 2603 |      rb_varargs_argc_check(rb_funcall_argc, rb_funcall_nargs), \
      |      ^~~~~~~~~~~~~~~~~~~~~
rugged_blame.c:246:10: note: in expansion of macro ‘rb_funcall’
  246 |   return rb_funcall(self, rb_intern("to_enum"), 1, CSTR2SYM("each"), self);
      |          ^~~~~~~~~~
rugged_blame.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
make: *** [Makefile:244: rugged_blame.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/jesalg/.rvm/gems/ruby-2.6.3/gems/rugged-0.26.7 for inspection.
Results logged to /home/jesalg/.rvm/gems/ruby-2.6.3/extensions/x86_64-linux/2.6.0/rugged-0.26.7/gem_make.out
```
</details>

It was, however, able to compile successfully with libgit2 v27 hence bumping the version.