### PR TITLE
Switch default branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Use [Test Driven Development](http://en.wikipedia.org/wiki/Test-driven_developme
 * Follow [best practices](http://robots.thoughtbot.com/post/48933156625/5-useful-tips-for-a-better-commit-message) for git commit messages to communicate your changes.
 * Add [ticket references to commits to automatically trigger product management workflows](http://help.sprint.ly/knowledgebase/articles/108139-available-scm-vcs-commands)
 * Only write the **minimal** amount of code necessary to accomplish the given task.
-* Ensure branch stays up-to-date with latest changes that are merged into master by using: `$ git update`
+* Ensure branch stays up-to-date with latest changes that are merged into main by using: `$ git update`
 * Changes that are not directly related to the current feature should be cherry-picked into their own branch and merged separately.
 
 ### Testing Protips&trade;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/wireframe/gitx.png?branch=master)](https://travis-ci.org/wireframe/gitx)
+[![Build Status](https://travis-ci.org/wireframe/gitx.png?branch=main)](https://travis-ci.org/wireframe/gitx)
 [![Code Coverage](https://coveralls.io/repos/wireframe/gitx/badge.png)](https://coveralls.io/r/wireframe/gitx)
 [![Code Climate](https://codeclimate.com/github/wireframe/gitx.png)](https://codeclimate.com/github/wireframe/gitx)
 
@@ -47,7 +47,7 @@ This setting is cleared when a reviewer approves or rejects the pull request.
 
 ## git release <feature_branch_name (optional, default: current_branch)
 
-release the feature branch to the base branch (by default, master).  This operation will perform the following:
+release the feature branch to the base branch (by default, main).  This operation will perform the following:
 
 * pull latest code from remote feature branch
 * pull latest code from the base branch

--- a/lib/gitx/cli/cleanup_command.rb
+++ b/lib/gitx/cli/cleanup_command.rb
@@ -5,7 +5,7 @@ require 'gitx/cli/base_command'
 module Gitx
   module Cli
     class CleanupCommand < BaseCommand
-      desc 'cleanup', 'Cleanup branches that have been merged into master from the repo'
+      desc 'cleanup', 'Cleanup branches that have been merged into main from the repo'
       def cleanup
         update_base_branch
         say 'Deleting local and remote branches that have been merged into '

--- a/lib/gitx/cli/start_command.rb
+++ b/lib/gitx/cli/start_command.rb
@@ -8,7 +8,7 @@ module Gitx
       EXAMPLE_BRANCH_NAMES = %w[api-fix-invalid-auth desktop-cleanup-avatar-markup share-form-add-edit-link].freeze
       VALID_BRANCH_NAME_REGEX = /^[A-Za-z0-9\-_]+$/.freeze
 
-      desc 'start', 'start a new git branch with latest changes from master'
+      desc 'start', 'start a new git branch with latest changes from main'
       method_option :issue, type: :string, aliases: '-i', desc: 'Issue identifier'
       def start(branch_name = nil)
         branch_name = ask("What would you like to name your branch? (ex: #{EXAMPLE_BRANCH_NAMES.sample})") until valid_new_branch_name?(branch_name)

--- a/lib/gitx/cli/update_command.rb
+++ b/lib/gitx/cli/update_command.rb
@@ -5,7 +5,7 @@ require 'gitx/cli/base_command'
 module Gitx
   module Cli
     class UpdateCommand < BaseCommand
-      desc 'update', 'Update the current branch with latest changes from the remote feature branch and master'
+      desc 'update', 'Update the current branch with latest changes from the remote feature branch and main'
       def update
         say 'Updating '
         say "#{current_branch.name} ", :green

--- a/lib/gitx/defaults.yml
+++ b/lib/gitx/defaults.yml
@@ -1,6 +1,6 @@
 ---
 # default base branch
-base_branch: master
+base_branch: main
 
 # Label to use for releasing a pull request, if this is set a label will be
 # added to the PR rather than merging to the base branch
@@ -14,14 +14,14 @@ aggregate_branches:
 # list of branches that should not be deleted when cleaning up
 reserved_branches:
   - HEAD
-  - master
+  - main
   - next_release
   - staging
   - prototype
 
 # list of supported branches for generating buildtags
 taggable_branches:
-  - master
+  - main
   - staging
 
 # list of commands to execute after releasing feature branch

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '3.2.0'.freeze
+  VERSION = '4.0.0'.freeze
 end

--- a/spec/gitx/cli/buildtag_command_spec.rb
+++ b/spec/gitx/cli/buildtag_command_spec.rb
@@ -23,7 +23,7 @@ describe Gitx::Cli::BuildtagCommand do
         expect { cli.buildtag }.to raise_error(/Branch must be one of the supported taggable branches/)
       end
     end
-    context 'when options[:branch] is NOT master or staging' do
+    context 'when options[:branch] is NOT main or staging' do
       let(:options) do
         {
           branch: 'feature-branch'
@@ -33,16 +33,16 @@ describe Gitx::Cli::BuildtagCommand do
         expect { cli.buildtag }.to raise_error(/Branch must be one of the supported taggable branches/)
       end
     end
-    context 'when options[:branch] is master' do
+    context 'when options[:branch] is main' do
       let(:options) do
         {
-          branch: 'master'
+          branch: 'main'
         }
       end
       before do
         Timecop.freeze(Time.utc(2013, 10, 30, 10, 21, 28)) do
-          expect(executor).to receive(:execute).with('git', 'tag', 'builds/master/2013-10-30-10-21-28', '--annotate', '--message', '[gitx] buildtag for master').ordered
-          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'builds/master/2013-10-30-10-21-28').ordered
+          expect(executor).to receive(:execute).with('git', 'tag', 'builds/main/2013-10-30-10-21-28', '--annotate', '--message', '[gitx] buildtag for main').ordered
+          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'builds/main/2013-10-30-10-21-28').ordered
           cli.buildtag
         end
       end
@@ -53,14 +53,14 @@ describe Gitx::Cli::BuildtagCommand do
     context 'when options[:message] is passed' do
       let(:options) do
         {
-          branch: 'master',
+          branch: 'main',
           message: 'custom git commit message'
         }
       end
       before do
         Timecop.freeze(Time.utc(2013, 10, 30, 10, 21, 28)) do
-          expect(executor).to receive(:execute).with('git', 'tag', 'builds/master/2013-10-30-10-21-28', '--annotate', '--message', 'custom git commit message').ordered
-          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'builds/master/2013-10-30-10-21-28').ordered
+          expect(executor).to receive(:execute).with('git', 'tag', 'builds/main/2013-10-30-10-21-28', '--annotate', '--message', 'custom git commit message').ordered
+          expect(executor).to receive(:execute).with('git', 'push', 'origin', 'builds/main/2013-10-30-10-21-28').ordered
           cli.buildtag
         end
       end

--- a/spec/gitx/cli/cleanup_command_spec.rb
+++ b/spec/gitx/cli/cleanup_command_spec.rb
@@ -38,7 +38,7 @@ describe Gitx::Cli::CleanupCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(executor).to receive(:execute).with('git', 'remote', 'prune', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', 'merged-local-feature').ordered
@@ -58,7 +58,7 @@ describe Gitx::Cli::CleanupCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(executor).to receive(:execute).with('git', 'remote', 'prune', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'merged-remote-feature').ordered
@@ -78,7 +78,7 @@ describe Gitx::Cli::CleanupCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
         expect(executor).to receive(:execute).with('git', 'remote', 'prune', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'merged-remote-feature/review').ordered

--- a/spec/gitx/cli/integrate_command_spec.rb
+++ b/spec/gitx/cli/integrate_command_spec.rb
@@ -47,18 +47,18 @@ describe Gitx::Cli::IntegrateCommand do
         should meet_expectations
       end
     end
-    context 'when current_branch == master' do
-      let(:current_branch) { double('fake branch', name: 'master', head?: true) }
-      let(:local_branch_names) { ['master'] }
+    context 'when current_branch == main' do
+      let(:current_branch) { double('fake branch', name: 'main', head?: true) }
+      let(:local_branch_names) { ['main'] }
       let(:remote_branch_names) { ['origin/staging'] }
       before do
         expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'staging').ordered
-        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Integrate master into staging', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', '[gitx] Integrate main into staging', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
 
         cli.integrate
       end
@@ -85,7 +85,7 @@ describe Gitx::Cli::IntegrateCommand do
         expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'log', 'origin/master...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return(changelog).ordered
+        expect(executor).to receive(:execute).with('git', 'log', 'origin/main...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return(changelog).ordered
         expect(executor).to receive(:execute).with('git', 'fetch', 'origin').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'staging').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'staging').ordered
@@ -109,7 +109,7 @@ describe Gitx::Cli::IntegrateCommand do
     context 'when staging branch does not exist remotely' do
       let(:remote_branch_names) { [] }
       before do
-        expect(repo).to receive(:create_branch).with('staging', 'master')
+        expect(repo).to receive(:create_branch).with('staging', 'main')
 
         expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'staging:staging').ordered

--- a/spec/gitx/cli/nuke_command_spec.rb
+++ b/spec/gitx/cli/nuke_command_spec.rb
@@ -22,26 +22,26 @@ describe Gitx::Cli::NukeCommand do
   end
 
   describe '#nuke' do
-    context 'when target branch == prototype and --destination == master' do
+    context 'when target branch == prototype and --destination == main' do
       let(:options) do
         {
           destination: good_branch
         }
       end
-      let(:good_branch) { 'master' }
+      let(:good_branch) { 'main' }
       let(:bad_branch) { 'prototype' }
-      let(:buildtag) { double(:tag, name: 'builds/master/2013-10-01-01') }
+      let(:buildtag) { double(:tag, name: 'builds/main/2013-10-01-01') }
       let(:tags) { [buildtag] }
       before do
         expect(cli).to receive(:yes?).and_return(true)
 
         expect(executor).to receive(:execute).with('git', 'fetch', '--tags').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'prototype').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'builds/master/2013-10-01-01').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'builds/main/2013-10-01-01').ordered
         expect(executor).to receive(:execute).with('git', 'share').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
 
         cli.nuke bad_branch
       end
@@ -50,21 +50,21 @@ describe Gitx::Cli::NukeCommand do
       end
     end
     context 'when target branch == prototype and destination prompt == nil' do
-      let(:good_branch) { 'master' }
+      let(:good_branch) { 'main' }
       let(:bad_branch) { 'prototype' }
-      let(:buildtag) { double(:tag, name: 'builds/master/2013-10-01-01') }
+      let(:buildtag) { double(:tag, name: 'builds/main/2013-10-01-01') }
       let(:tags) { [buildtag] }
       before do
         expect(cli).to receive(:ask).and_return(good_branch)
         expect(cli).to receive(:yes?).and_return(true)
 
         expect(executor).to receive(:execute).with('git', 'fetch', '--tags').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'prototype').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'builds/master/2013-10-01-01').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'builds/main/2013-10-01-01').ordered
         expect(executor).to receive(:execute).with('git', 'share').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
 
         cli.nuke 'prototype'
       end
@@ -73,14 +73,14 @@ describe Gitx::Cli::NukeCommand do
       end
     end
     context 'when user does not confirm nuking the target branch' do
-      let(:buildtag) { double(:tag, name: 'builds/master/2013-10-01-01') }
+      let(:buildtag) { double(:tag, name: 'builds/main/2013-10-01-01') }
       let(:tags) { [buildtag] }
       before do
-        expect(cli).to receive(:ask).and_return('master')
+        expect(cli).to receive(:ask).and_return('main')
         expect(cli).to receive(:yes?).and_return(false)
 
         expect(executor).to receive(:execute).with('git', 'fetch', '--tags').ordered
-        expect(executor).to_not receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to_not receive(:execute).with('git', 'checkout', 'main').ordered
 
         cli.nuke 'prototype'
       end
@@ -94,7 +94,7 @@ describe Gitx::Cli::NukeCommand do
           destination: good_branch
         }
       end
-      let(:good_branch) { 'master' }
+      let(:good_branch) { 'main' }
       let(:bad_branch) { 'prototype' }
       let(:buildtags) { '' }
       it 'raises error' do
@@ -103,9 +103,9 @@ describe Gitx::Cli::NukeCommand do
       end
     end
     context 'when database migrations exist and user cancels operation' do
-      let(:buildtag) { double(:tag, name: 'builds/master/2013-10-01-01') }
+      let(:buildtag) { double(:tag, name: 'builds/main/2013-10-01-01') }
       let(:tags) { [buildtag] }
-      let(:good_branch) { 'master' }
+      let(:good_branch) { 'main' }
       let(:bad_branch) { 'prototype' }
       let(:migrations) do
         %w[db/migrate/20140715194946_create_users.rb db/migrate/20140730063034_update_user_account.rb].join("\n")
@@ -115,8 +115,8 @@ describe Gitx::Cli::NukeCommand do
 
         expect(executor).to receive(:execute).with('git', 'fetch', '--tags').ordered
         expect(cli).to receive(:ask).and_return(good_branch)
-        expect(cli).to receive(:yes?).with('Reset prototype to builds/master/2013-10-01-01? (y/n)', :green).and_return(true)
-        expect(executor).to receive(:execute).with('git', 'diff', 'builds/master/2013-10-01-01...prototype', '--name-only', 'db/migrate').and_return(migrations)
+        expect(cli).to receive(:yes?).with('Reset prototype to builds/main/2013-10-01-01? (y/n)', :green).and_return(true)
+        expect(executor).to receive(:execute).with('git', 'diff', 'builds/main/2013-10-01-01...prototype', '--name-only', 'db/migrate').and_return(migrations)
         expect(cli).to receive(:yes?).with('Are you sure you want to nuke prototype? (y/n) ', :green).and_return(false)
 
         cli.nuke 'prototype'
@@ -129,9 +129,9 @@ describe Gitx::Cli::NukeCommand do
       end
     end
     context 'when database migrations exist and user approves operation' do
-      let(:buildtag) { double(:tag, name: 'builds/master/2013-10-01-01') }
+      let(:buildtag) { double(:tag, name: 'builds/main/2013-10-01-01') }
       let(:tags) { [buildtag] }
-      let(:good_branch) { 'master' }
+      let(:good_branch) { 'main' }
       let(:bad_branch) { 'prototype' }
       let(:migrations) do
         %w[db/migrate/20140715194946_create_users.rb db/migrate/20140730063034_update_user_account.rb].join("\n")
@@ -140,17 +140,17 @@ describe Gitx::Cli::NukeCommand do
         FileUtils.mkdir_p('db/migrate')
 
         expect(cli).to receive(:ask).and_return(good_branch)
-        expect(cli).to receive(:yes?).with('Reset prototype to builds/master/2013-10-01-01? (y/n)', :green).and_return(true)
-        expect(executor).to receive(:execute).with('git', 'diff', 'builds/master/2013-10-01-01...prototype', '--name-only', 'db/migrate').and_return(migrations)
+        expect(cli).to receive(:yes?).with('Reset prototype to builds/main/2013-10-01-01? (y/n)', :green).and_return(true)
+        expect(executor).to receive(:execute).with('git', 'diff', 'builds/main/2013-10-01-01...prototype', '--name-only', 'db/migrate').and_return(migrations)
         expect(cli).to receive(:yes?).with('Are you sure you want to nuke prototype? (y/n) ', :green).and_return(true)
 
         expect(executor).to receive(:execute).with('git', 'fetch', '--tags').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'branch', '--delete', '--force', 'prototype').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', '--delete', 'prototype').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'builds/master/2013-10-01-01').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', '-b', 'prototype', 'builds/main/2013-10-01-01').ordered
         expect(executor).to receive(:execute).with('git', 'share').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
 
         cli.nuke 'prototype'
       end

--- a/spec/gitx/cli/release_command_spec.rb
+++ b/spec/gitx/cli/release_command_spec.rb
@@ -36,14 +36,14 @@ describe Gitx::Cli::ReleaseCommand do
       before do
         expect(repo).to receive(:workdir).and_return(temp_dir)
 
-        expect(cli).to receive(:yes?).with('Release feature-branch to master? (y/n)', :green).and_return(true)
+        expect(cli).to receive(:yes?).with('Release feature-branch to main? (y/n)', :green).and_return(true)
         expect(cli).to receive(:yes?).with('Branch status is currently: failure.  Proceed with release? (y/n)', :red).and_return(false)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to_not receive(:execute).with('git', 'checkout', 'master')
-        expect(executor).to_not receive(:execute).with('git', 'pull', 'origin', 'master')
-        expect(executor).to_not receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to master\n\nConnected to #10", 'feature-branch')
+        expect(executor).to_not receive(:execute).with('git', 'checkout', 'main')
+        expect(executor).to_not receive(:execute).with('git', 'pull', 'origin', 'main')
+        expect(executor).to_not receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch')
         expect(executor).to_not receive(:execute).with('git', 'push', 'origin', 'HEAD')
 
         VCR.use_cassette('pull_request_does_exist_with_failure_status') do
@@ -64,9 +64,9 @@ describe Gitx::Cli::ReleaseCommand do
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to master\n\nConnected to #10", 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
         expect(executor).to receive(:execute).with('git integrate').ordered
 
@@ -94,9 +94,9 @@ describe Gitx::Cli::ReleaseCommand do
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to master\n\nConnected to #10", 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
         expect(executor).to receive(:execute).with('echo hello').ordered
 
@@ -117,9 +117,9 @@ describe Gitx::Cli::ReleaseCommand do
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to master\n\nConnected to #10", 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
         expect(executor).to receive(:execute).with('git integrate').ordered
 
@@ -147,17 +147,17 @@ describe Gitx::Cli::ReleaseCommand do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         allow(cli).to receive(:ask_editor).and_return('description')
 
-        expect(cli).to receive(:yes?).with('Release feature-branch to master? (y/n)', :green).and_return(true)
+        expect(cli).to receive(:yes?).with('Release feature-branch to main? (y/n)', :green).and_return(true)
         expect(cli).to receive(:yes?).with('Branch status is currently: pending.  Proceed with release? (y/n)', :red).and_return(true)
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'log', 'origin/master...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return('2013-01-01 did some stuff').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to master\n\nConnected to #10", 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'log', 'origin/main...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return('2013-01-01 did some stuff').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
         expect(executor).to receive(:execute).with('git integrate').ordered
 
@@ -187,9 +187,9 @@ describe Gitx::Cli::ReleaseCommand do
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'checkout', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
-        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to master\n\nConnected to #10", 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
         expect(executor).to receive(:execute).with('git integrate').ordered
         expect(executor).to receive(:execute).with('git cleanup').ordered
@@ -218,9 +218,9 @@ describe Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:label_pull_request).with(having_attributes(number: 10), 'release-me').and_call_original
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
-        expect(executor).to_not receive(:execute).with('git', 'checkout', 'master')
-        expect(executor).to_not receive(:execute).with('git', 'pull', 'origin', 'master')
-        expect(executor).to_not receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to master\n\nConnected to #10", 'feature-branch')
+        expect(executor).to_not receive(:execute).with('git', 'checkout', 'main')
+        expect(executor).to_not receive(:execute).with('git', 'pull', 'origin', 'main')
+        expect(executor).to_not receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch')
         expect(executor).to_not receive(:execute).with('git', 'push', 'origin', 'HEAD')
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered

--- a/spec/gitx/cli/review_command_spec.rb
+++ b/spec/gitx/cli/review_command_spec.rb
@@ -46,7 +46,7 @@ describe Gitx::Cli::ReviewCommand do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'log', 'origin/master...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return(changelog).ordered
+        expect(executor).to receive(:execute).with('git', 'log', 'origin/main...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return(changelog).ordered
         expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return('description')
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
@@ -82,11 +82,11 @@ describe Gitx::Cli::ReviewCommand do
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git', 'log', 'origin/master...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return(changelog).ordered
+        expect(executor).to receive(:execute).with('git', 'log', 'origin/main...feature-branch', '--reverse', '--no-merges', '--pretty=format:* %B').and_return(changelog).ordered
         expect(cli).to receive(:ask_editor).with(changelog, hash_including(footer: Gitx::Github::PULL_REQUEST_FOOTER)).and_return(pull_request_description)
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls')
-          .with(body: { base: 'master', head: 'feature-branch', title: 'feature branch', body: pull_request_description }.to_json)
+          .with(body: { base: 'main', head: 'feature-branch', title: 'feature branch', body: pull_request_description }.to_json)
           .to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
 
         VCR.use_cassette('pull_request_does_not_exist') do

--- a/spec/gitx/cli/start_command_spec.rb
+++ b/spec/gitx/cli/start_command_spec.rb
@@ -16,9 +16,9 @@ describe Gitx::Cli::StartCommand do
   describe '#start' do
     context 'when user inputs branch that is valid' do
       before do
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', '[gitx] Start work on new-branch').ordered
 
@@ -30,9 +30,9 @@ describe Gitx::Cli::StartCommand do
     end
     context 'when user inputs branch with slash' do
       before do
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('foo/ryan', 'master').ordered
+        expect(repo).to receive(:create_branch).with('foo/ryan', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('foo/ryan').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', '[gitx] Start work on foo/ryan').ordered
 
@@ -46,9 +46,9 @@ describe Gitx::Cli::StartCommand do
       before do
         expect(cli).to receive(:ask).and_return('new-branch')
 
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', '[gitx] Start work on new-branch').ordered
 
@@ -62,9 +62,9 @@ describe Gitx::Cli::StartCommand do
       before do
         expect(cli).to receive(:ask).and_return('new-branch')
 
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', '[gitx] Start work on new-branch').ordered
 
@@ -81,9 +81,9 @@ describe Gitx::Cli::StartCommand do
 
         expect(cli).to receive(:ask).and_return('new-branch')
 
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', '[gitx] Start work on new-branch').ordered
 
@@ -100,9 +100,9 @@ describe Gitx::Cli::StartCommand do
 
         expect(cli).to receive(:ask).and_return('new-branch')
 
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', '[gitx] Start work on new-branch').ordered
 
@@ -119,9 +119,9 @@ describe Gitx::Cli::StartCommand do
         }
       end
       before do
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', "[gitx] Start work on new-branch\n\nConnected to #10").ordered
 
@@ -138,9 +138,9 @@ describe Gitx::Cli::StartCommand do
         }
       end
       before do
-        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:checkout_branch).with('main').ordered
         expect(executor).to receive(:execute).with('git', 'pull').ordered
-        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'main').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
         expect(executor).to receive(:execute).with('git', 'commit', '--allow-empty', '--message', "[gitx] Start work on new-branch\n\nConnected to FOO-123").ordered
 

--- a/spec/gitx/cli/update_command_spec.rb
+++ b/spec/gitx/cli/update_command_spec.rb
@@ -28,7 +28,7 @@ describe Gitx::Cli::UpdateCommand do
         allow(cli).to receive(:say)
 
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'share').ordered
 
         cli.update
@@ -49,12 +49,12 @@ describe Gitx::Cli::UpdateCommand do
         should meet_expectations
       end
     end
-    context 'when merge conflicts occur when pulling remote master branch' do
+    context 'when merge conflicts occur when pulling remote main branch' do
       before do
         allow(cli).to receive(:say)
 
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').and_raise(Gitx::Executor::ExecutionError).ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').and_raise(Gitx::Executor::ExecutionError).ordered
 
         expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge conflict occurred. Please fix merge conflict and rerun the command')
       end
@@ -68,7 +68,7 @@ describe Gitx::Cli::UpdateCommand do
         allow(cli).to receive(:say)
 
         expect(executor).not_to receive(:execute).with('git', 'pull', 'origin', 'feature-branch')
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'master').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
 
         cli.update
       end


### PR DESCRIPTION
Change the default configured branch from `master` to the more inclusive
`main`.

https://sfconservancy.org/news/2020/jun/23/gitbranchname/

Since this is a breaking change, I also updated the version number to `4.0.0`.

It would be great if, once this change is merged, you could also rename the default branch in the Github branch settings:
https://github.com/github/renaming#renaming-existing-branches