### PR TITLE
Update local main branch during `git update`

### DIFF
--- a/lib/gitx/cli/update_command.rb
+++ b/lib/gitx/cli/update_command.rb
@@ -14,10 +14,19 @@ module Gitx
 
         update_branch(current_branch.name) if remote_branch_exists?(current_branch.name)
         update_branch(config.base_branch)
+        update_base_branch
+
         run_git_cmd 'share'
       end
 
       private
+
+      def update_base_branch
+        branch_name = current_branch.name
+        checkout_branch(config.base_branch)
+        update_branch(config.base_branch)
+        checkout_branch(branch_name)
+      end
 
       def update_branch(branch)
         run_git_cmd 'pull', 'origin', branch

--- a/lib/gitx/cli/update_command.rb
+++ b/lib/gitx/cli/update_command.rb
@@ -12,9 +12,9 @@ module Gitx
         say 'with latest changes from '
         say config.base_branch, :green
 
-        update_branch(current_branch.name) if remote_branch_exists?(current_branch.name)
-        update_branch(config.base_branch)
         update_base_branch
+        update_branch(current_branch.name) if remote_branch_exists?(current_branch.name)
+        update_branch(config.base_branch, repository: '.')
 
         run_git_cmd 'share'
       end
@@ -28,8 +28,8 @@ module Gitx
         checkout_branch(branch_name)
       end
 
-      def update_branch(branch)
-        run_git_cmd 'pull', 'origin', branch
+      def update_branch(branch, repository: 'origin')
+        run_git_cmd 'pull', repository, branch
       rescue Gitx::Executor::ExecutionError
         raise MergeError, 'Merge conflict occurred. Please fix merge conflict and rerun the command'
       end

--- a/spec/gitx/cli/update_command_spec.rb
+++ b/spec/gitx/cli/update_command_spec.rb
@@ -29,6 +29,9 @@ describe Gitx::Cli::UpdateCommand do
 
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'share').ordered
 
         cli.update
@@ -69,6 +72,9 @@ describe Gitx::Cli::UpdateCommand do
 
         expect(executor).not_to receive(:execute).with('git', 'pull', 'origin', 'feature-branch')
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
 
         cli.update
       end

--- a/spec/gitx/cli/update_command_spec.rb
+++ b/spec/gitx/cli/update_command_spec.rb
@@ -27,11 +27,11 @@ describe Gitx::Cli::UpdateCommand do
       before do
         allow(cli).to receive(:say)
 
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', '.', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'share').ordered
 
         cli.update
@@ -44,6 +44,9 @@ describe Gitx::Cli::UpdateCommand do
       before do
         allow(cli).to receive(:say)
 
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').and_raise(Gitx::Executor::ExecutionError).ordered
 
         expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge conflict occurred. Please fix merge conflict and rerun the command')
@@ -56,8 +59,11 @@ describe Gitx::Cli::UpdateCommand do
       before do
         allow(cli).to receive(:say)
 
+        expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'feature-branch').ordered
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').and_raise(Gitx::Executor::ExecutionError).ordered
+        expect(executor).to receive(:execute).with('git', 'pull', '.', 'main').and_raise(Gitx::Executor::ExecutionError).ordered
 
         expect { cli.update }.to raise_error(Gitx::Cli::BaseCommand::MergeError, 'Merge conflict occurred. Please fix merge conflict and rerun the command')
       end
@@ -71,10 +77,11 @@ describe Gitx::Cli::UpdateCommand do
         allow(cli).to receive(:say)
 
         expect(executor).not_to receive(:execute).with('git', 'pull', 'origin', 'feature-branch')
-        expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
+        expect(executor).to receive(:execute).with('git', 'pull', '.', 'main').ordered
+        expect(executor).to receive(:execute).with('git', 'share').ordered
 
         cli.update
       end


### PR DESCRIPTION
This ensures that the local main branch is updated during `git update`. Without this it's necessary for the end user to run `git update` separately on the main branch, and it can be confusing if they e.g. want to diff their newly-updated feature branch against the main branch and don't realize it's stale. This happens to me fairly often and I couldn't think of a reason someone _wouldn't_ want their main branch updated so this seemed like a sane change.