### PR TITLE
Mitigate post-release race condition with pull request

### DIFF
--- a/lib/gitx/cli/integrate_command.rb
+++ b/lib/gitx/cli/integrate_command.rb
@@ -9,6 +9,7 @@ module Gitx
     class IntegrateCommand < BaseCommand
       include Gitx::Github
       desc 'integrate', 'integrate the current branch into one of the aggregate development branches (default = staging)'
+      method_option :'skip-pull-request', type: :boolean, desc: 'skip pull request reference in merge commit'
       method_option :resume, type: :string, aliases: '-r', desc: 'resume merging of feature-branch'
       def integrate(integration_branch = 'staging')
         assert_aggregate_branch!(integration_branch)
@@ -17,7 +18,7 @@ module Gitx
         print_message(branch, integration_branch)
 
         run_git_cmd 'update'
-        pull_request = pull_request_for_branch(branch)
+        pull_request = pull_request_for_branch(branch) unless options[:'skip-pull-request']
         integrate_branch(branch, integration_branch, pull_request) unless options[:resume]
         checkout_branch branch
       end

--- a/lib/gitx/defaults.yml
+++ b/lib/gitx/defaults.yml
@@ -26,4 +26,4 @@ taggable_branches:
 
 # list of commands to execute after releasing feature branch
 after_release:
-  - git integrate
+  - git integrate --skip-pull-request

--- a/spec/gitx/cli/release_command_spec.rb
+++ b/spec/gitx/cli/release_command_spec.rb
@@ -68,7 +68,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
-        expect(executor).to receive(:execute).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git integrate --skip-pull-request').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.release
@@ -121,7 +121,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
-        expect(executor).to receive(:execute).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git integrate --skip-pull-request').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.release 'feature-branch'
@@ -159,7 +159,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
-        expect(executor).to receive(:execute).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git integrate --skip-pull-request').ordered
 
         stub_request(:post, 'https://api.github.com/repos/wireframe/gitx/pulls').to_return(status: 201, body: new_pull_request.to_json, headers: { 'Content-Type' => 'application/json' })
         VCR.use_cassette('pull_request_does_not_exist') do
@@ -191,7 +191,7 @@ describe Gitx::Cli::ReleaseCommand do
         expect(executor).to receive(:execute).with('git', 'pull', 'origin', 'main').ordered
         expect(executor).to receive(:execute).with('git', 'merge', '--no-ff', '--message', "[gitx] Release feature-branch to main\n\nConnected to #10", 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'push', 'origin', 'HEAD').ordered
-        expect(executor).to receive(:execute).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git integrate --skip-pull-request').ordered
         expect(executor).to receive(:execute).with('git cleanup').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
@@ -225,7 +225,7 @@ describe Gitx::Cli::ReleaseCommand do
 
         expect(executor).to receive(:execute).with('git', 'checkout', 'feature-branch').ordered
         expect(executor).to receive(:execute).with('git', 'update').ordered
-        expect(executor).to receive(:execute).with('git integrate').ordered
+        expect(executor).to receive(:execute).with('git integrate --skip-pull-request').ordered
 
         VCR.use_cassette('pull_request_does_exist_with_success_status_and_then_add_label') do
           cli.release


### PR DESCRIPTION
Since we've switched over to using `release_branch`, sometimes the merge tool will merge and close the pull request between when `git release` adds the label and when it runs `git integrate`. This causes `gitx` to not be able to find the PR (since it's no longer `open`) and prompts the user to create one.

This works around that issue by adding a `--no-pull-request` option to `git integrate` to skip the pull request reference, and specifying that option in the `after_release` default config.

Another option to resolve this might be to have `gitx` conditionally check for closed pull requests as well, but that seemed like unnecessary complexity.