### PR TITLE
git review: Use .github/PULL_REQUEST_TEMPLATE.md in PR desc, if it exists in the repo

### DIFF
--- a/lib/gitx/github.rb
+++ b/lib/gitx/github.rb
@@ -17,6 +17,7 @@ module Gitx
       #
       # This footer will automatically be stripped from the pull request description
     MESSAGE
+    PULL_REQEST_TEMPLATE_FILE='.github/PULL_REQUEST_TEMPLATE.md'
 
     def find_or_create_pull_request(branch)
       pull_request = find_pull_request(branch)
@@ -82,12 +83,21 @@ module Gitx
       description_template = []
       description_template << "#{description}\n" if description
       description_template << changelog
+      description_template << "#{pull_request_template}\n" if pull_request_template
 
       ask_editor(description_template.join("\n"), editor: repo.config['core.editor'], footer: PULL_REQUEST_FOOTER)
     end
 
     def pull_request_title(branch)
       options[:title] || branch.gsub(/[-_]/, ' ')
+    end
+
+    def pull_request_template_file
+      File.expand_path(PULL_REQEST_TEMPLATE_FILE)
+    end
+
+    def pull_request_template
+      @pull_request_template ||= File.exist?(pull_request_template_file) ? File.read(pull_request_template_file) : nil
     end
 
     # authorization token used for github API calls


### PR DESCRIPTION
## Purpose
While using `git review` on a repository that has a `.github/PULL_REQUEST_TEMPLATE.md`, I noted that the command does not use the template when creating a new Github PR.

## Summary
This PR adds functionality to detect if the current repo has a `.github/PULL_REQUEST_TEMPLATE.md` file, and if it does, it inserts it into the PR body after the description and changelog.

## Guidance
- Is this a usable feature outside of my own use-case?
- Is it ok to assume that if that file exists, ALL repos that use `git review` will want to default to using that template file?
  - e.g. should we make it the default, or give the dev an option to use or not use the found template?