### PR TITLE
Make update during release optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This setting is cleared when a reviewer approves or rejects the pull request.
 release the feature branch to the base branch (by default, main).  This operation will perform the following:
 
 * pull latest code from remote feature branch
-* pull latest code from the base branch
+* pull latest code from the base branch (unless `update_from_base_on_release` config is set to `false`)
 * prompt user to confirm they actually want to perform the release
 * check if pull request commit status is currently successful
 * merge current branch into the base branch (or add release label if configured)

--- a/lib/gitx/configuration.rb
+++ b/lib/gitx/configuration.rb
@@ -45,6 +45,10 @@ module Gitx
       taggable_branches.include?(branch)
     end
 
+    def update_from_base_on_release?
+      config.fetch(:update_from_base_on_release, true)
+    end
+
     def after_release_scripts
       config[:after_release]
     end

--- a/lib/gitx/version.rb
+++ b/lib/gitx/version.rb
@@ -1,3 +1,3 @@
 module Gitx
-  VERSION = '4.1.1'.freeze
+  VERSION = '4.2.0'.freeze
 end


### PR DESCRIPTION
When a repository uses a merge tool, the merge tool typically already performs and update from the base branch as part of evaluating the changeset. In this case updating from the base branch locally as part of the release process can actually add latency to the release process, since CI will typically have to run again after the merge before the changeset can enter the merge queue.

This change adds a new `update_from_base_on_release` configuration that can be set to `false` to bypass the update.