### PR TITLE
Ruby 3.2.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@
 # versions of RuboCop, may require this file to be generated again.
 
 AllCops:
-  TargetRubyVersion: '2.6'
+  TargetRubyVersion: '2.7'
 
 FileName:
   Exclude:

--- a/gitx.gemspec
+++ b/gitx.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ['lib']
 
   spec.add_runtime_dependency 'octokit'
-  spec.add_runtime_dependency 'rugged', '~> 0.27.10'
+  spec.add_runtime_dependency 'rugged'
   spec.add_runtime_dependency 'thor'
 
   spec.add_development_dependency 'bundler'

--- a/gitx.gemspec
+++ b/gitx.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary               = 'Utility scripts for Git to increase productivity for common operations'
   spec.homepage              = ''
   spec.license               = 'MIT'
-  spec.required_ruby_version = '>= 2.6.7'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.files                 = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables           = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
* Drop support for Ruby 2.6 as [it has been EOL since 2022-04-12](https://www.ruby-lang.org/en/downloads/branches/)
* Remove version restriction on `rugged` as [older versions of rugged error on Ruby 3.2.0](https://github.com/libgit2/rugged/issues/943)

I did some light testing on Ruby 3.2.0 and it seemed to work well.