### PR TITLE
Remove obsolete Github OAuth Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ options:
 * `--branch` = configure the branch name related to the build tag
 * `--message` = configure the git message associated to the tag
 
+## Authentication
+
+In order to access any of the Github APIs you will need to generate [a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with `repo` scopes. You will be prompted for this token before gitx accesses the Github API. After you provide the token it will be saved in `~/.config/gitx.yml` so you don't need to provide it again.
+
 ## Configuration
 Any of the [default settings defined in the gem](lib/gitx/defaults.yml) can be overridden
 by creating a custom `.gitx.yml` file in the root directory of your project.

--- a/lib/gitx/github.rb
+++ b/lib/gitx/github.rb
@@ -108,28 +108,15 @@ module Gitx
     def authorization_token
       auth_token = ENV['GITX_GITHUB_TOKEN'] || global_config['token']
       auth_token ||= begin
-        new_token = create_authorization
+        new_token = fetch_token
         save_global_config('token' => new_token)
         new_token
       end
       auth_token
     end
 
-    def create_authorization
-      password = ask_without_echo("Github password for #{username}: ")
-      client = Octokit::Client.new(login: username, password: password)
-      options = {
-        scopes: ['repo'],
-        note: github_client_name,
-        note_url: CLIENT_URL
-      }
-      two_factor_auth_token = ask_without_echo('Github two factor authorization token (if enabled): ')
-      options[:headers] = { 'X-GitHub-OTP' => two_factor_auth_token } if two_factor_auth_token
-      response = client.create_authorization(options)
-      response.token
-    rescue Octokit::ClientError => e
-      say "Error creating authorization: #{e.message}", :red
-      retry
+    def fetch_token
+      ask_without_echo("Github personal access token with repo scopes for #{username}: ")
     end
 
     def github_client_name

--- a/spec/gitx/cli/review_command_spec.rb
+++ b/spec/gitx/cli/review_command_spec.rb
@@ -293,48 +293,16 @@ describe Gitx::Cli::ReviewCommand do
           'github.user' => 'ryan@codecrate.com'
         }
       end
-      let(:github_password) { 'secretz' }
-      let(:authorization_token) { '123981239123' }
+      let(:github_personal_access_token) { 'secretz' }
       before do
-        stub_request(:post, 'https://api.github.com/authorizations')
-          .with(basic_auth: ['ryan@codecrate.com', 'secretz'])
-          .to_return(status: 200, body: JSON.dump(token: authorization_token), headers: { 'Content-Type' => 'application/json' })
-
-        expect(cli).to receive(:ask).with('Github password for ryan@codecrate.com: ', echo: false).and_return(github_password)
-        expect(cli).to receive(:ask).with('Github two factor authorization token (if enabled): ', echo: false).and_return(nil)
+        expect(cli).to receive(:ask).with('Github personal access token for ryan@codecrate.com: ', echo: false).and_return(github_personal_access_token)
 
         @auth_token = cli.send(:authorization_token)
       end
       it 'stores authorization_token in global config' do
-        expect(global_config).to include('token' => authorization_token)
+        expect(global_config).to include('token' => github_personal_access_token)
       end
-      it { expect(@auth_token).to eq authorization_token }
-    end
-    context 'when global authorization_token is nil and first request fails' do
-      let(:repo_config) do
-        {
-          'remote.origin.url' => 'https://github.com/wireframe/gitx',
-          'github.user' => 'ryan@codecrate.com'
-        }
-      end
-      let(:github_password) { 'secretz' }
-      let(:authorization_token) { '123981239123' }
-      before do
-        stub_request(:post, 'https://api.github.com/authorizations')
-          .with(basic_auth: ['ryan@codecrate.com', 'secretz'])
-          .to_return(status: 401, body: JSON.dump(token: authorization_token), headers: { 'Content-Type' => 'application/json' })
-          .then
-          .to_return(status: 200, body: JSON.dump(token: authorization_token), headers: { 'Content-Type' => 'application/json' })
-
-        expect(cli).to receive(:ask).with('Github password for ryan@codecrate.com: ', echo: false).and_return(github_password).twice
-        expect(cli).to receive(:ask).with('Github two factor authorization token (if enabled): ', echo: false).and_return(nil).twice
-
-        @auth_token = cli.send(:authorization_token)
-      end
-      it 'stores authorization_token in global config' do
-        expect(global_config).to include('token' => authorization_token)
-      end
-      it { expect(@auth_token).to eq authorization_token }
+      it { expect(@auth_token).to eq github_personal_access_token }
     end
     context 'when the global config has an existing token' do
       let(:authorization_token) { '123981239123' }
@@ -354,32 +322,6 @@ describe Gitx::Cli::ReviewCommand do
           file.write(config.to_yaml)
         end
         @auth_token = cli.send(:authorization_token)
-      end
-      it { expect(@auth_token).to eq authorization_token }
-    end
-    context 'when two factor authorization token given' do
-      let(:repo_config) do
-        {
-          'remote.origin.url' => 'https://github.com/wireframe/gitx',
-          'github.user' => 'ryan@codecrate.com'
-        }
-      end
-      let(:github_password) { 'secretz' }
-      let(:authorization_token) { '123981239123' }
-      let(:two_factor_auth_token) { '456456' }
-      before do
-        stub_request(:post, 'https://api.github.com/authorizations')
-          .with(basic_auth: ['ryan@codecrate.com', 'secretz'])
-          .with(headers: { 'X-GitHub-OTP' => two_factor_auth_token })
-          .to_return(status: 200, body: JSON.dump(token: authorization_token), headers: { 'Content-Type' => 'application/json' })
-
-        expect(cli).to receive(:ask).with('Github password for ryan@codecrate.com: ', echo: false).and_return(github_password)
-        expect(cli).to receive(:ask).with('Github two factor authorization token (if enabled): ', echo: false).and_return(two_factor_auth_token)
-
-        @auth_token = cli.send(:authorization_token)
-      end
-      it 'stores authorization_token in global config' do
-        expect(global_config).to include('token' => authorization_token)
       end
       it { expect(@auth_token).to eq authorization_token }
     end


### PR DESCRIPTION
The Github OAuth Authorization API [was deprecated back in 2020](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/) and [removed from Octokit in 2022](https://github.com/octokit/octokit.rb/issues/1429).

This change updates the library to ask for the personal access token directly.